### PR TITLE
Fix weighted Euler results with Lorenz

### DIFF
--- a/examples/fractional-lorenz.py
+++ b/examples/fractional-lorenz.py
@@ -53,7 +53,7 @@ stepper = CaputoWeightedEulerMethod(
     source=partial(lorenz, sigma=sigma, rho=rho, beta=beta),
     source_jac=partial(lorenz_jac, sigma=sigma, rho=rho, beta=beta),
     y0=(y0,),
-    theta=1.0,
+    theta=0.5,
 )
 
 from pycaputo.fode import StepCompleted, evolve


### PR DESCRIPTION
Does not seem to give the limit cycle for `theta=0.5` but it does for `theta=1.0` (forward Euler).

Fixes #38.