### PR TITLE
Add Integrate-and-Fire schemes

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,6 +7,6 @@ Files: docs/* *.md *.rst *.cfg pyproject.toml requirements* Makefile MANIFEST.in
 Copyright: 2023 Alexandru Fikl <alexfikl@gmail.com>
 License: CC0-1.0
 
-Files: .gitignore .codespell-ignore .readthedocs.yml .gitlab-ci.yml .github/*
+Files: .gitignore .codespell-ignore .readthedocs.yml .broken.gitlab-ci.yml .github/*
 Copyright: 2023 Alexandru Fikl <alexfikl@gmail.com>
 License: CC0-1.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ pycaputo documentation
     controllers
     timestepping
     fode
+    integrate_fire
     misc
     references
     changelog

--- a/docs/integrate_fire.rst
+++ b/docs/integrate_fire.rst
@@ -1,0 +1,39 @@
+.. _sec-fire:
+
+Integrate-and-Fire Models
+=========================
+
+Interfaces
+----------
+
+.. class:: pycaputo.integrate_fire.ModelT
+
+    A :class:`~typing.TypeVar` bound to
+    :class:`~pycaputo.integrate_fire.IntegrateFireModel`.
+
+.. class:: pycaputo.integrate_fire.base.ModelT
+
+    See :class:`~pycaputo.integrate_fire.ModelT`. This is just documented here
+    to satisfy Sphinx.
+
+.. automodule:: pycaputo.integrate_fire
+
+Perfect Integrate-and-Fire Model
+--------------------------------
+
+.. automodule:: pycaputo.integrate_fire.pif
+
+Leaky Integrate-and-Fire Model
+------------------------------
+
+.. automodule:: pycaputo.integrate_fire.lif
+
+Exponential Integrate-and-Fire Model
+------------------------------------
+
+.. automodule:: pycaputo.integrate_fire.eif
+
+Adaptive Exponential Integrate-and-Fire Model
+---------------------------------------------
+
+.. automodule:: pycaputo.integrate_fire.ad_ex

--- a/docs/integrate_fire.rst
+++ b/docs/integrate_fire.rst
@@ -6,15 +6,7 @@ Integrate-and-Fire Models
 Interfaces
 ----------
 
-.. class:: pycaputo.integrate_fire.IntegrateFireModelT
-
-    A :class:`~typing.TypeVar` bound to
-    :class:`~pycaputo.integrate_fire.IntegrateFireModel`.
-
-.. class:: pycaputo.integrate_fire.base.IntegrateFireModelT
-
-    See :class:`~pycaputo.integrate_fire.IntegrateFireModelT`. This is just
-    documented here to satisfy Sphinx.
+.. autoclass:: pycaputo.integrate_fire.IntegrateFireModelT
 
 .. automodule:: pycaputo.integrate_fire
 
@@ -37,3 +29,5 @@ Adaptive Exponential Integrate-and-Fire Model
 ---------------------------------------------
 
 .. automodule:: pycaputo.integrate_fire.ad_ex
+
+.. autoclass:: pycaputo.integrate_fire.base.IntegrateFireModelT

--- a/docs/integrate_fire.rst
+++ b/docs/integrate_fire.rst
@@ -6,15 +6,15 @@ Integrate-and-Fire Models
 Interfaces
 ----------
 
-.. class:: pycaputo.integrate_fire.ModelT
+.. class:: pycaputo.integrate_fire.IntegrateFireModelT
 
     A :class:`~typing.TypeVar` bound to
     :class:`~pycaputo.integrate_fire.IntegrateFireModel`.
 
-.. class:: pycaputo.integrate_fire.base.ModelT
+.. class:: pycaputo.integrate_fire.base.IntegrateFireModelT
 
-    See :class:`~pycaputo.integrate_fire.ModelT`. This is just documented here
-    to satisfy Sphinx.
+    See :class:`~pycaputo.integrate_fire.IntegrateFireModelT`. This is just
+    documented here to satisfy Sphinx.
 
 .. automodule:: pycaputo.integrate_fire
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -83,3 +83,8 @@ References
     *A Novel Adaptive Procedure for Solving Fractional Differential Equations*,
     Journal of Computational Science, Vol. 47, pp. 101220--101220, 2020,
     `DOI <https://doi.org/10.1016/j.jocs.2020.101220>`__.
+
+.. [Naud2008] R. Naud, N. Marcille, C. Clopath, W. Gerstner,
+    *Firing Patterns in the Adaptive Exponential Integrate-and-Fire Model*,
+    Biological Cybernetics, Vol. 99, pp. 335--347, 2008,
+    `DOI <https://doi.org/10.1007/s00422-008-0264-7>`__.

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -106,7 +106,8 @@ t = np.array(ts)
 y = np.array(ys).T
 eest = np.array(eests)
 
-with figure("integrate-fire-adex-v") as fig:
+basename = f"integrate-fire-adex-{100 * alpha:.0f}"
+with figure(f"{basename}-v") as fig:
     ax = fig.gca()
 
     ax.plot(t, y[0], lw=3)
@@ -117,7 +118,7 @@ with figure("integrate-fire-adex-v") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$V$ (mV)")
 
-with figure("integrate-fire-adex-w") as fig:
+with figure(f"{basename}-w") as fig:
     ax = fig.gca()
 
     ax.plot(t, y[1], lw=3)
@@ -127,7 +128,7 @@ with figure("integrate-fire-adex-w") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$w$ (pA)")
 
-with figure("integrate-fire-adex-dt") as fig:
+with figure(f"{basename}-dt") as fig:
     ax = fig.gca()
 
     ax.semilogy(t[:-1], np.diff(t))
@@ -136,7 +137,7 @@ with figure("integrate-fire-adex-dt") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel(r"$\Delta t$ (ms)")
 
-with figure("integrate-fire-adex-eest") as fig:
+with figure(f"{basename}-eest") as fig:
     ax = fig.gca()
 
     ax.plot(t, eest)

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -77,8 +77,8 @@ stepper = ad_ex.CaputoAdExIntegrateFireL1Model(
 
 # {{{ evolution
 
-from pycaputo.fode import evolve
 from pycaputo.integrate_fire import StepAccepted, StepRejected
+from pycaputo.stepping import evolve
 
 ts = []
 ys = []

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -20,11 +20,11 @@ logger = get_logger("integrate-and-fire")
 # {{{ model
 
 # time interval
-tstart, tfinal = 0.0, 24.0
+tstart, tfinal = 0.0, 256.0
 # fractional order
-alpha = 0.8
+alpha = 0.99, 0.99
 
-param = ad_ex.get_ad_ex_parameters("Naud4h")
+param = ad_ex.get_ad_ex_parameters("Naud4f")
 model = ad_ex.AdExModel(param.nondim(alpha))
 
 logger.info("Parameters:\n%s", model.param)
@@ -37,20 +37,23 @@ from pycaputo.controller import make_jannelli_controller
 
 # initial condition
 rng = np.random.default_rng()
-y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
+y0 = np.array([
+    rng.uniform(model.param.v_reset - 10, model.param.v_reset),
+    rng.uniform(),
+])
 
 dtinit = 1.0e-1
 c = make_jannelli_controller(
     tstart,
     tfinal,
     dtmin=1.0e-5,
-    chimin=0.05,
-    chimax=1.0,
+    chimin=0.001,
+    chimax=0.01,
     abstol=1.0e-4,
 )
 
 stepper = ad_ex.CaputoAdExIntegrateFireL1Model(
-    derivative_order=(alpha,),
+    derivative_order=alpha,
     control=c,
     y0=(y0,),
     source=model.source,
@@ -100,42 +103,47 @@ set_recommended_matplotlib()
 # vectorize variables
 s = np.array(spikes)
 t = np.array(ts)
-y = np.array(ys).squeeze()
+y = np.array(ys).T
 eest = np.array(eests)
 
-# make variables dimensional for plotting
-dim = model.param.ref
-t = dim.time(t)
-y = dim.var(y)
-
-with figure("integrate-fire-lif") as fig:
+with figure("integrate-fire-adex-v") as fig:
     ax = fig.gca()
 
-    ax.plot(t, y, lw=3)
-    ax.axhline(param.v_peak, color="k", ls="-")
-    ax.axhline(param.v_reset, color="k", ls="--")
-    ax.plot(t[s], y[s], "ro")
+    ax.plot(t, y[0], lw=3)
+    ax.axhline(model.param.v_peak, color="k", ls="-")
+    ax.axhline(model.param.v_reset, color="k", ls="--")
+    ax.plot(t[s], y[0][s], "ro")
 
-    ax.set_xlabel("$t$")
-    ax.set_ylabel("$V$")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel("$V$ (mV)")
 
-with figure("integrate-fire-lif-dt") as fig:
+with figure("integrate-fire-adex-w") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, y[1], lw=3)
+    ax.plot(t[s], y[1][s], "r^")
+    ax.plot(t[s], y[1][s] + model.param.b, "rv")
+
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel("$w$ (pA)")
+
+with figure("integrate-fire-adex-dt") as fig:
     ax = fig.gca()
 
     ax.semilogy(t[:-1], np.diff(t))
-    ax.axhline(dim.time(dtinit), color="k", ls="--")
-    ax.axhline(dim.time(c.dtmin), color="k", ls="--")
-    ax.set_xlabel("$t$")
-    ax.set_ylabel(r"$\Delta t$")
+    ax.axhline(dtinit, color="k", ls="--")
+    ax.axhline(c.dtmin, color="k", ls="--")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel(r"$\Delta t$ (ms)")
 
-with figure("integrate-fire-lif-eest") as fig:
+with figure("integrate-fire-adex-eest") as fig:
     ax = fig.gca()
 
     ax.plot(t, eest)
     ax.axhline(1.0, color="k", ls="--")
     ax.axhline(0.0, color="k", ls="--")
     ax.plot(t[s], eest[s], "ro")
-    ax.set_xlabel("$t$")
+    ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$E_{est}$")
 
 # }}}

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -69,8 +69,7 @@ stepper = ad_ex.CaputoAdExIntegrateFireL1Model(
     derivative_order=alpha,
     control=c,
     y0=(y0,),
-    source=model.source,
-    model=model,
+    source=model,
 )
 
 # }}}

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -15,60 +15,127 @@ import numpy as np
 from pycaputo.integrate_fire import ad_ex
 from pycaputo.logging import get_logger
 
-logger = get_logger("ad-ex")
+logger = get_logger("integrate-and-fire")
 
+# {{{ model
+
+# time interval
+tstart, tfinal = 0.0, 24.0
+# fractional order
+alpha = 0.8
+
+param = ad_ex.get_ad_ex_parameters("Naud4h")
+model = ad_ex.AdExModel(param.nondim(alpha))
+
+logger.info("Parameters:\n%s", model.param)
+
+# }}}
 
 # {{{ setup
 
-# Fractional derivative order
-alpha = (0.9, 0.9)
-# simulation time span (non-dimensional)
-tstart = 0.0
-tfinal = 50.0
-# simulation time step (non-dimensional)
-dt = 1.0e-2
-
-# NOTE: parameters taken from Table 1, Figure 4h in [Naud2008]
-pd = ad_ex.get_ad_ex_parameters("Naud4h")
-p = pd.nondim(alpha)
-model = ad_ex.AdExModel(p)
-
-# initial condition
-rng = np.random.default_rng(seed=None)
-y0 = np.array([
-    rng.uniform(p.v_reset, p.v_peak),
-    rng.uniform(0.0, 1.0),
-])
-
 from pycaputo.controller import make_jannelli_controller
 
+# initial condition
+rng = np.random.default_rng()
+y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
+
+dtinit = 1.0e-1
 c = make_jannelli_controller(
     tstart,
     tfinal,
-    dtmin=1.0e-3,
-    chimin=0.01,
+    dtmin=1.0e-5,
+    chimin=0.05,
     chimax=1.0,
     abstol=1.0e-4,
 )
 
-m = ad_ex.AdExIntegrateFireL1Method(
-    derivative_order=alpha,
+stepper = ad_ex.CaputoAdExIntegrateFireL1Model(
+    derivative_order=(alpha,),
     control=c,
     y0=(y0,),
     source=model.source,
     model=model,
 )
 
-logger.info("Dimensional variables:\n%s", pd)
-logger.info("Non-dimensional variables:\n%s", p)
-
 # }}}
 
-
 # {{{ evolution
+
+from pycaputo.fode import evolve
+from pycaputo.integrate_fire import StepAccepted, StepRejected
+
+ts = []
+ys = []
+spikes = []
+eests = []
+
+for event in evolve(stepper, dtinit=dtinit):
+    if isinstance(event, StepAccepted):
+        ts.append(event.t)
+        ys.append(event.y)
+        eests.append(event.eest)
+
+        if event.spiked:
+            spikes.append(event.iteration)
+    elif isinstance(event, StepRejected):
+        pass
+    else:
+        raise RuntimeError(event)
+
+    logger.info("%s energy %.5e eest %+.5e", event, np.linalg.norm(event.y), event.eest)
 
 # }}}
 
 # {{{ plotting
+
+try:
+    import matplotlib  # noqa: F401
+except ImportError as exc:
+    raise SystemExit(0) from exc
+
+from pycaputo.utils import figure, set_recommended_matplotlib
+
+set_recommended_matplotlib()
+
+# vectorize variables
+s = np.array(spikes)
+t = np.array(ts)
+y = np.array(ys).squeeze()
+eest = np.array(eests)
+
+# make variables dimensional for plotting
+dim = model.param.ref
+t = dim.time(t)
+y = dim.var(y)
+
+with figure("integrate-fire-lif") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, y, lw=3)
+    ax.axhline(param.v_peak, color="k", ls="-")
+    ax.axhline(param.v_reset, color="k", ls="--")
+    ax.plot(t[s], y[s], "ro")
+
+    ax.set_xlabel("$t$")
+    ax.set_ylabel("$V$")
+
+with figure("integrate-fire-lif-dt") as fig:
+    ax = fig.gca()
+
+    ax.semilogy(t[:-1], np.diff(t))
+    ax.axhline(dim.time(dtinit), color="k", ls="--")
+    ax.axhline(dim.time(c.dtmin), color="k", ls="--")
+    ax.set_xlabel("$t$")
+    ax.set_ylabel(r"$\Delta t$")
+
+with figure("integrate-fire-lif-eest") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, eest)
+    ax.axhline(1.0, color="k", ls="--")
+    ax.axhline(0.0, color="k", ls="--")
+    ax.plot(t[s], eest[s], "ro")
+    ax.set_xlabel("$t$")
+    ax.set_ylabel("$E_{est}$")
 
 # }}}

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# This model is taken from [Naud2008] with the same parameters
+#
+# .. [Naud2008] R. Naud, N. Marcille, C. Clopath, W. Gerstner,
+#       *Firing Patterns in the Adaptive Exponential Integrate-and-Fire Model*,
+#       Biological Cybernetics, Vol. 99, pp. 335--347, 2008,
+#       `DOI <https://doi.org/10.1007/s00422-008-0264-7>`__.
+
+from __future__ import annotations
+
+import numpy as np
+
+from pycaputo.integrate_fire import ad_ex
+from pycaputo.logging import get_logger
+
+logger = get_logger("ad-ex")
+
+
+# {{{ setup
+
+# Fractional derivative order
+alpha = (0.9, 0.9)
+# simulation time span (non-dimensional)
+tstart = 0.0
+tfinal = 50.0
+# simulation time step (non-dimensional)
+dt = 1.0e-2
+
+# NOTE: parameters taken from Table 1, Figure 4h in [Naud2008]
+pd = ad_ex.get_ad_ex_parameters("Naud4h")
+p = pd.nondim(alpha)
+model = ad_ex.AdExModel(p)
+
+# initial condition
+rng = np.random.default_rng(seed=None)
+y0 = np.array([
+    rng.uniform(p.v_reset, p.v_peak),
+    rng.uniform(0.0, 1.0),
+])
+
+from pycaputo.controller import make_jannelli_controller
+
+c = make_jannelli_controller(
+    tstart,
+    tfinal,
+    dtmin=1.0e-3,
+    chimin=0.01,
+    chimax=1.0,
+    abstol=1.0e-4,
+)
+
+m = ad_ex.AdExIntegrateFireL1Method(
+    derivative_order=alpha,
+    control=c,
+    y0=(y0,),
+    source=model.source,
+    model=model,
+)
+
+logger.info("Dimensional variables:\n%s", pd)
+logger.info("Non-dimensional variables:\n%s", p)
+
+# }}}
+
+
+# {{{ evolution
+
+# }}}
+
+# {{{ plotting
+
+# }}}

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import numpy as np
+
+from pycaputo.integrate_fire import eif
+from pycaputo.logging import get_logger
+
+logger = get_logger("integrate-and-fire")
+
+# {{{ model
+
+# time interval
+tstart, tfinal = 0.0, 10.0
+# fractional order
+alpha = 0.95
+
+param = eif.EIFDim(
+    current=160,
+    C=100,
+    gl=12.0,
+    e_leak=-60.0,
+    delta_t=2.0,
+    vt=-50.0,
+    v_reset=-48,
+    v_peak=0.0,
+)
+model = eif.EIFModel(param.nondim(alpha))
+
+logger.info("Parameters:\n%s", param)
+logger.info("Parameters:\n%s", model.param)
+
+# }}}
+
+# {{{ setup
+
+from pycaputo.controller import make_jannelli_controller
+
+# initial condition
+rng = np.random.default_rng()
+y0 = np.array([rng.uniform(model.param.v_reset - 2.0, model.param.v_reset)])
+
+dtinit = 1.0e-3
+c = make_jannelli_controller(
+    tstart,
+    tfinal,
+    dtmin=1.0e-5,
+    chimin=0.01,
+    chimax=0.1,
+    abstol=1.0e-4,
+)
+
+stepper = eif.CaputoExponentialIntegrateFireL1Method(
+    derivative_order=(alpha,),
+    control=c,
+    y0=(y0,),
+    source=model.source,
+    model=model,
+)
+
+# }}}
+
+# {{{ evolution
+
+from pycaputo.integrate_fire import StepAccepted, StepRejected, evolve
+
+ts = []
+ys = []
+spikes = []
+eests = []
+
+for event in evolve(stepper, dtinit=dtinit):
+    if isinstance(event, StepAccepted):
+        ts.append(event.t)
+        ys.append(event.y)
+        eests.append(event.eest)
+
+        if event.spiked:
+            spikes.append(event.iteration)
+    elif isinstance(event, StepRejected):
+        pass
+    else:
+        raise RuntimeError("Evolution failed!")
+
+    logger.info(
+        "[%06d] t = %.5e dt = %.5e energy %.5e eest %+.5e",
+        event.iteration,
+        event.t,
+        event.dt,
+        np.linalg.norm(event.y),
+        event.eest,
+    )
+
+# }}}
+
+# {{{ plotting
+
+try:
+    import matplotlib  # noqa: F401
+except ImportError as exc:
+    raise SystemExit(0) from exc
+
+from pycaputo.utils import figure, set_recommended_matplotlib
+
+set_recommended_matplotlib()
+t = np.array(ts)
+s = np.array(spikes)
+
+y = np.array(ys).squeeze()
+eest = np.array(eests)
+
+# dimensionalize variables
+t = t / model.param.T
+y = param.delta_t * y + param.vt
+
+with figure("integrate-fire-eif") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, y, lw=3)
+    ax.axhline(param.v_peak, color="k", ls="-")
+    ax.axhline(param.v_reset, color="k", ls="--")
+    ax.plot(t[s], y[s], "ro")
+
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel("$V$ (mV)")
+
+with figure("integrate-fire-eif-dt") as fig:
+    ax = fig.gca()
+
+    ax.semilogy(t[:-1], np.diff(t))
+    ax.axhline(dtinit, color="k", ls="--")
+    ax.axhline(c.dtmin, color="k", ls="--")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel(r"$\Delta t$ (ms)")
+
+with figure("integrate-fire-eif-eest") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, eest)
+    ax.axhline(1.0, color="k", ls="--")
+    ax.axhline(0.0, color="k", ls="--")
+    ax.plot(t[s], eest[s], "ro")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel("$E_{est}$")
+
+# }}}

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -64,8 +64,8 @@ stepper = eif.CaputoExponentialIntegrateFireL1Method(
 
 # {{{ evolution
 
-from pycaputo.fode import evolve
 from pycaputo.integrate_fire import StepAccepted, StepRejected
+from pycaputo.stepping import evolve
 
 ts = []
 ys = []

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -111,7 +111,8 @@ dim = model.param.ref
 t = dim.time(t)
 y = dim.var(y)
 
-with figure("integrate-fire-eif") as fig:
+basename = f"integrate-fire-eif-{100 * alpha:.0f}"
+with figure(basename) as fig:
     ax = fig.gca()
 
     ax.plot(t, y, lw=3)
@@ -123,7 +124,7 @@ with figure("integrate-fire-eif") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$V$ (mV)")
 
-with figure("integrate-fire-eif-dt") as fig:
+with figure(f"{basename}-dt") as fig:
     ax = fig.gca()
 
     ax.semilogy(t[:-1], np.diff(t))
@@ -132,7 +133,7 @@ with figure("integrate-fire-eif-dt") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel(r"$\Delta t$ (ms)")
 
-with figure("integrate-fire-eif-eest") as fig:
+with figure(f"{basename}-eest") as fig:
     ax = fig.gca()
 
     ax.plot(t, eest)

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -83,16 +83,9 @@ for event in evolve(stepper, dtinit=dtinit):
     elif isinstance(event, StepRejected):
         pass
     else:
-        raise RuntimeError("Evolution failed!")
+        raise RuntimeError(event)
 
-    logger.info(
-        "[%06d] t = %.5e dt = %.5e energy %.5e eest %+.5e",
-        event.iteration,
-        event.t,
-        event.dt,
-        np.linalg.norm(event.y),
-        event.eest,
-    )
+    logger.info("%s energy %.5e eest %+.5e", event, np.linalg.norm(event.y), event.eest)
 
 # }}}
 

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -13,7 +13,7 @@ logger = get_logger("integrate-and-fire")
 # {{{ model
 
 # time interval
-tstart, tfinal = 0.0, 10.0
+tstart, tfinal = 0.0, 50.0
 # fractional order
 alpha = 0.95
 
@@ -40,7 +40,7 @@ from pycaputo.controller import make_jannelli_controller
 
 # initial condition
 rng = np.random.default_rng()
-y0 = np.array([rng.uniform(model.param.v_reset - 2.0, model.param.v_reset)])
+y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
 dtinit = 1.0e-3
 c = make_jannelli_controller(
@@ -109,7 +109,7 @@ eest = np.array(eests)
 # dimensionalize variables
 dim = model.param.ref
 t = dim.time(t)
-y = dim.potential(y)
+y = dim.var(y)
 
 with figure("integrate-fire-eif") as fig:
     ax = fig.gca()

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -64,7 +64,8 @@ stepper = eif.CaputoExponentialIntegrateFireL1Method(
 
 # {{{ evolution
 
-from pycaputo.integrate_fire import StepAccepted, StepRejected, evolve
+from pycaputo.fode import evolve
+from pycaputo.integrate_fire import StepAccepted, StepRejected
 
 ts = []
 ys = []
@@ -105,15 +106,17 @@ except ImportError as exc:
 from pycaputo.utils import figure, set_recommended_matplotlib
 
 set_recommended_matplotlib()
+
+# vectorize variables
 t = np.array(ts)
 s = np.array(spikes)
-
-y = np.array(ys).squeeze()
+y = np.array(ys)
 eest = np.array(eests)
 
 # dimensionalize variables
-t = t / model.param.T
-y = param.delta_t * y + param.vt
+dim = model.param.ref
+t = dim.time(t)
+y = dim.potential(y)
 
 with figure("integrate-fire-eif") as fig:
     ax = fig.gca()
@@ -121,6 +124,7 @@ with figure("integrate-fire-eif") as fig:
     ax.plot(t, y, lw=3)
     ax.axhline(param.v_peak, color="k", ls="-")
     ax.axhline(param.v_reset, color="k", ls="--")
+    ax.axhline(param.vt, color="k", ls=":")
     ax.plot(t[s], y[s], "ro")
 
     ax.set_xlabel("$t$ (ms)")
@@ -130,8 +134,8 @@ with figure("integrate-fire-eif-dt") as fig:
     ax = fig.gca()
 
     ax.semilogy(t[:-1], np.diff(t))
-    ax.axhline(dtinit, color="k", ls="--")
-    ax.axhline(c.dtmin, color="k", ls="--")
+    ax.axhline(dim.time(dtinit), color="k", ls="--")
+    ax.axhline(dim.time(c.dtmin), color="k", ls="--")
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel(r"$\Delta t$ (ms)")
 

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -56,8 +56,7 @@ stepper = eif.CaputoExponentialIntegrateFireL1Method(
     derivative_order=(alpha,),
     control=c,
     y0=(y0,),
-    source=model.source,
-    model=model,
+    source=model,
 )
 
 # }}}

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -32,9 +32,6 @@ from pycaputo.controller import make_jannelli_controller
 rng = np.random.default_rng()
 y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
-# tspike = model.param.first_spike_time(y0[0])
-# logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspike, tstart, tfinal)
-
 dtinit = 1.0e-1
 c = make_jannelli_controller(
     tstart,
@@ -98,12 +95,11 @@ s = np.array(spikes)
 t = np.array(ts)
 y = np.array(ys).squeeze()
 eest = np.array(eests)
-print(s)
 
 # make variables dimensional for plotting
 dim = model.param.ref
 t = dim.time(t)
-y = dim.potential(y)
+y = dim.var(y)
 
 with figure("integrate-fire-lif") as fig:
     ax = fig.gca()

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -61,8 +61,8 @@ stepper = lif.CaputoLeakyIntegrateFireL1Method(
 
 # {{{ evolution
 
-from pycaputo.fode import evolve
 from pycaputo.integrate_fire import StepAccepted, StepRejected
+from pycaputo.stepping import evolve
 
 ts = []
 ys = []

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -76,16 +76,9 @@ for event in evolve(stepper, dtinit=dtinit):
     elif isinstance(event, StepRejected):
         pass
     else:
-        raise RuntimeError("Evolution failed!")
+        raise RuntimeError(event)
 
-    logger.info(
-        "[%06d] t = %.5e dt = %.5e energy %.5e eest %+.5e",
-        event.iteration,
-        event.t,
-        event.dt,
-        np.linalg.norm(event.y),
-        event.eest,
-    )
+    logger.info("%s energy %.5e eest %+.5e", event, np.linalg.norm(event.y), event.eest)
 
 # }}}
 

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -109,8 +109,8 @@ with figure("integrate-fire-lif") as fig:
     ax.axhline(param.v_reset, color="k", ls="--")
     ax.plot(t[s], y[s], "ro")
 
-    ax.set_xlabel("$t$")
-    ax.set_ylabel("$V$")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel("$V$ (mV)")
 
 with figure("integrate-fire-lif-dt") as fig:
     ax = fig.gca()
@@ -118,8 +118,8 @@ with figure("integrate-fire-lif-dt") as fig:
     ax.semilogy(t[:-1], np.diff(t))
     ax.axhline(dim.time(dtinit), color="k", ls="--")
     ax.axhline(dim.time(c.dtmin), color="k", ls="--")
-    ax.set_xlabel("$t$")
-    ax.set_ylabel(r"$\Delta t$")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel(r"$\Delta t$ (ms)")
 
 with figure("integrate-fire-lif-eest") as fig:
     ax = fig.gca()
@@ -128,7 +128,7 @@ with figure("integrate-fire-lif-eest") as fig:
     ax.axhline(1.0, color="k", ls="--")
     ax.axhline(0.0, color="k", ls="--")
     ax.plot(t[s], eest[s], "ro")
-    ax.set_xlabel("$t$")
+    ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$E_{est}$")
 
 # }}}

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -53,8 +53,7 @@ stepper = lif.CaputoLeakyIntegrateFireL1Method(
     derivative_order=(alpha,),
     control=c,
     y0=(y0,),
-    source=model.source,
-    model=model,
+    source=model,
 )
 
 # }}}

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -33,7 +33,11 @@ rng = np.random.default_rng()
 y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
 tspikes = model.param.constant_spike_times(tfinal, V0=y0[0])
-logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspikes[0], tstart, tfinal)
+if tspikes:
+    logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspikes[0], tstart, tfinal)
+else:
+    logger.info("tstart %.8e, tfinal %.8e", tstart, tfinal)
+    logger.warning("No spikes should occur for this configuration.")
 
 dtinit = 1.0e-1
 c = make_jannelli_controller(
@@ -105,7 +109,8 @@ t = dim.time(t)
 y = dim.var(y)
 tspikes = dim.time(tspikes)
 
-with figure("integrate-fire-lif") as fig:
+basename = f"integrate-fire-lif-{100 * alpha:.0f}"
+with figure(basename) as fig:
     ax = fig.gca()
 
     ax.plot(t, y, lw=3)
@@ -117,7 +122,7 @@ with figure("integrate-fire-lif") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$V$ (mV)")
 
-with figure("integrate-fire-lif-dt") as fig:
+with figure(f"{basename}-dt") as fig:
     ax = fig.gca()
 
     ax.semilogy(t[:-1], np.diff(t))
@@ -126,7 +131,7 @@ with figure("integrate-fire-lif-dt") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel(r"$\Delta t$ (ms)")
 
-with figure("integrate-fire-lif-eest") as fig:
+with figure(f"{basename}-eest") as fig:
     ax = fig.gca()
 
     ax.plot(t, eest)

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import numpy as np
+
+from pycaputo.integrate_fire import lif
+from pycaputo.logging import get_logger
+
+logger = get_logger("integrate-and-fire")
+
+# {{{ model
+
+# time interval
+tstart, tfinal = 0.0, 1.0
+# fractional order
+alpha = 0.8
+
+param = lif.LIFDim(current=160, C=100, gl=1.0, e_leak=-50.0, v_reset=-48, v_peak=0.0)
+model = lif.LIFModel(param.nondim(alpha, v_ref=1.0))
+
+logger.info("Parameters:\n%s", model.param)
+
+# }}}
+
+# {{{ setup
+
+from pycaputo.controller import make_jannelli_controller
+
+# initial condition
+rng = np.random.default_rng()
+y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
+
+# tspike = model.param.first_spike_time(y0[0])
+# logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspike, tstart, tfinal)
+
+dtinit = 1.0e-1
+c = make_jannelli_controller(
+    tstart,
+    tfinal,
+    dtmin=1.0e-5,
+    chimin=0.05,
+    chimax=1.0,
+    abstol=1.0e-4,
+)
+
+stepper = lif.CaputoLeakyIntegrateFireL1Method(
+    derivative_order=(alpha,),
+    control=c,
+    y0=(y0,),
+    source=model.source,
+    model=model,
+)
+
+# }}}
+
+# {{{ evolution
+
+from pycaputo.integrate_fire import StepAccepted, StepRejected, evolve
+
+ts = []
+ys = []
+spikes = []
+eests = []
+
+for event in evolve(stepper, dtinit=dtinit):
+    if isinstance(event, StepAccepted):
+        ts.append(event.t)
+        ys.append(event.y)
+        eests.append(event.eest)
+
+        if event.spiked:
+            spikes.append(event.iteration)
+    elif isinstance(event, StepRejected):
+        pass
+    else:
+        raise RuntimeError("Evolution failed!")
+
+    logger.info(
+        "[%06d] t = %.5e dt = %.5e energy %.5e eest %+.5e",
+        event.iteration,
+        event.t,
+        event.dt,
+        np.linalg.norm(event.y),
+        event.eest,
+    )
+
+# }}}
+
+# {{{ plotting
+
+try:
+    import matplotlib  # noqa: F401
+except ImportError as exc:
+    raise SystemExit(0) from exc
+
+from pycaputo.utils import figure, set_recommended_matplotlib
+
+set_recommended_matplotlib()
+t = np.array(ts)
+s = np.array(spikes)
+
+y = np.array(ys).squeeze()
+eest = np.array(eests)
+
+with figure("integrate-fire-lif") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, y, lw=3)
+    ax.axhline(model.param.v_peak, color="k", ls="-")
+    ax.axhline(model.param.v_reset, color="k", ls="--")
+    ax.plot(t[s], y[s], "ro")
+
+    ax.set_xlabel("$t$")
+    ax.set_ylabel("$V$")
+
+with figure("integrate-fire-lif-dt") as fig:
+    ax = fig.gca()
+
+    ax.semilogy(t[:-1], np.diff(t))
+    ax.axhline(dtinit, color="k", ls="--")
+    ax.axhline(c.dtmin, color="k", ls="--")
+    ax.set_xlabel("$t$")
+    ax.set_ylabel(r"$\Delta t$")
+
+with figure("integrate-fire-lif-eest") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, eest)
+    ax.axhline(1.0, color="k", ls="--")
+    ax.axhline(0.0, color="k", ls="--")
+    ax.plot(t[s], eest[s], "ro")
+    ax.set_xlabel("$t$")
+    ax.set_ylabel("$E_{est}$")
+
+# }}}

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -15,7 +15,7 @@ logger = get_logger("integrate-and-fire")
 # time interval
 tstart, tfinal = 0.0, 24.0
 # fractional order
-alpha = 0.8
+alpha = 0.83
 
 param = lif.LIFDim(current=160, C=100, gl=3.0, e_leak=-50.0, v_reset=-48, v_peak=0.0)
 model = lif.LIFModel(param.nondim(alpha, V_ref=1.0))
@@ -31,6 +31,9 @@ from pycaputo.controller import make_jannelli_controller
 # initial condition
 rng = np.random.default_rng()
 y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
+
+tspikes = model.param.constant_spike_times(tfinal, V0=y0[0])
+logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspikes[0], tstart, tfinal)
 
 dtinit = 1.0e-1
 c = make_jannelli_controller(
@@ -100,6 +103,7 @@ eest = np.array(eests)
 dim = model.param.ref
 t = dim.time(t)
 y = dim.var(y)
+tspikes = dim.time(tspikes)
 
 with figure("integrate-fire-lif") as fig:
     ax = fig.gca()
@@ -108,6 +112,7 @@ with figure("integrate-fire-lif") as fig:
     ax.axhline(param.v_peak, color="k", ls="-")
     ax.axhline(param.v_reset, color="k", ls="--")
     ax.plot(t[s], y[s], "ro")
+    ax.plot(tspikes, np.full_like(tspikes, param.v_peak), "kx")
 
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$V$ (mV)")

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -62,8 +62,8 @@ stepper = pif.CaputoPerfectIntegrateFireL1Method(
 
 # {{{ evolution
 
-from pycaputo.fode import evolve
 from pycaputo.integrate_fire import StepAccepted, StepRejected
+from pycaputo.stepping import evolve
 
 ts = []
 ys = []
@@ -94,7 +94,7 @@ try:
 except ImportError as exc:
     raise SystemExit(0) from exc
 
-from pycaputo.utils import figure, set_recommended_matplotlib
+from pycaputo.utils import figure, gamma, set_recommended_matplotlib
 
 set_recommended_matplotlib()
 
@@ -106,7 +106,7 @@ eest = np.array(eests)
 
 # get exact solution up to the second spike
 t_ref = t[: s[1]]
-y_ref = y0 + model.param.current * t_ref**alpha / stepper.gamma1p
+y_ref = y0 + model.param.current * t_ref**alpha / gamma(1 + alpha)
 
 # make variables dimensional for plotting
 dim = model.param.ref

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -32,8 +32,8 @@ from pycaputo.controller import make_jannelli_controller
 rng = np.random.default_rng()
 y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
-tspike = model.param.first_spike_time(y0[0])
-logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspike, tstart, tfinal)
+tspikes = model.param.constant_spike_times(tfinal, V0=y0[0])
+logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspikes[0], tstart, tfinal)
 
 dtinit = 1.0e-1
 c = make_jannelli_controller(
@@ -109,6 +109,7 @@ t = dim.time(t)
 y = dim.var(y)
 t_ref = dim.time(t_ref)
 y_ref = dim.var(y_ref)
+tspikes = dim.time(tspikes)
 
 with figure("integrate-fire-pif") as fig:
     ax = fig.gca()
@@ -118,7 +119,7 @@ with figure("integrate-fire-pif") as fig:
     ax.axhline(param.v_peak, color="k", ls="-")
     ax.axhline(param.v_reset, color="k", ls="--")
     ax.plot(t[s], y[s], "ro")
-    ax.axvline(dim.time(tspike), ls="--")
+    ax.plot(tspikes, np.full_like(tspikes, param.v_peak), "kx")
 
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$V$ (mV)")

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import numpy as np
+
+from pycaputo.integrate_fire import pif
+from pycaputo.logging import get_logger
+
+logger = get_logger("integrate-and-fire")
+
+# {{{ model
+
+# time interval
+tstart, tfinal = 0.0, 32.0
+# fractional order
+alpha = 0.8
+
+param = pif.PIFDim(current=160, C=100, v_reset=-48, v_peak=0.0)
+model = pif.PIFModel(param.nondim(alpha, v_ref=1.0, I_ref=20.0))
+
+logger.info("Parameters:\n%s", model.param)
+
+# }}}
+
+# {{{ setup
+
+from pycaputo.controller import make_jannelli_controller
+
+# initial condition
+rng = np.random.default_rng()
+y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
+
+tspike = model.param.first_spike_time(y0[0])
+logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspike, tstart, tfinal)
+
+dtinit = 1.0e-1
+c = make_jannelli_controller(
+    tstart,
+    tfinal,
+    dtmin=1.0e-5,
+    chimin=0.01,
+    chimax=0.1,
+    abstol=1.0e-4,
+)
+
+stepper = pif.CaputoPerfectIntegrateFireL1Method(
+    derivative_order=(alpha,),
+    control=c,
+    y0=(y0,),
+    source=model.source,
+    model=model,
+)
+
+# }}}
+
+# {{{ evolution
+
+from pycaputo.integrate_fire import StepAccepted, StepRejected, evolve
+
+ts = []
+ys = []
+spikes = []
+eests = []
+
+for event in evolve(stepper, dtinit=dtinit):
+    if isinstance(event, StepAccepted):
+        ts.append(event.t)
+        ys.append(event.y)
+        eests.append(event.eest)
+
+        if event.spiked:
+            spikes.append(event.iteration)
+    elif isinstance(event, StepRejected):
+        pass
+    else:
+        raise RuntimeError("Evolution failed!")
+
+    logger.info(
+        "[%06d] t = %.5e dt = %.5e energy %.5e eest %.5e",
+        event.iteration,
+        event.t,
+        event.dt,
+        event.eest,
+        np.linalg.norm(event.y),
+    )
+
+# }}}
+
+# {{{ plotting
+
+try:
+    import matplotlib  # noqa: F401
+except ImportError as exc:
+    raise SystemExit(0) from exc
+
+from pycaputo.utils import figure, set_recommended_matplotlib
+
+set_recommended_matplotlib()
+t = np.array(ts)
+s = np.array(spikes)
+
+y = np.array(ys).squeeze()
+y_ref = (y0 + model.param.current * t**alpha / stepper.gamma1p).squeeze()
+
+eest = np.array(eests)
+
+with figure("integrate-fire-pif") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, y, lw=3)
+    ax.plot(t, y_ref, "k--")
+    ax.axhline(model.param.v_peak, color="k", ls="-")
+    ax.axhline(model.param.v_reset, color="k", ls="--")
+    ax.plot(t[s], y[s], "ro")
+    ax.axvline(tspike, ls="--")
+
+    ax.set_xlabel("$t$")
+    ax.set_ylabel("$V$")
+
+with figure("integrate-fire-pif-dt") as fig:
+    ax = fig.gca()
+
+    ax.semilogy(t[:-1], np.diff(t))
+    ax.axhline(dtinit, color="k", ls="--")
+    ax.axhline(c.dtmin, color="k", ls="--")
+    ax.set_xlabel("$t$")
+    ax.set_ylabel(r"$\Delta t$")
+
+with figure("integrate-fire-pif-eest") as fig:
+    ax = fig.gca()
+
+    ax.plot(t, eest)
+    ax.axhline(1.0, color="k", ls="--")
+    ax.axhline(0.0, color="k", ls="--")
+    ax.plot(t[s], eest[s], "ro")
+    ax.set_xlabel("$t$")
+    ax.set_ylabel("$E_{est}$")
+
+# }}}

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -106,9 +106,9 @@ y_ref = y0 + model.param.current * t_ref**alpha / stepper.gamma1p
 # make variables dimensional for plotting
 dim = model.param.ref
 t = dim.time(t)
-y = dim.potential(y)
+y = dim.var(y)
 t_ref = dim.time(t_ref)
-y_ref = dim.potential(y_ref)
+y_ref = dim.var(y_ref)
 
 with figure("integrate-fire-pif") as fig:
     ax = fig.gca()

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -120,8 +120,8 @@ with figure("integrate-fire-pif") as fig:
     ax.plot(t[s], y[s], "ro")
     ax.axvline(dim.time(tspike), ls="--")
 
-    ax.set_xlabel("$t$")
-    ax.set_ylabel("$V$")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel("$V$ (mV)")
 
 with figure("integrate-fire-pif-dt") as fig:
     ax = fig.gca()
@@ -129,8 +129,8 @@ with figure("integrate-fire-pif-dt") as fig:
     ax.semilogy(t[:-1], np.diff(t))
     ax.axhline(dim.time(dtinit), color="k", ls="--")
     ax.axhline(dim.time(c.dtmin), color="k", ls="--")
-    ax.set_xlabel("$t$")
-    ax.set_ylabel(r"$\Delta t$")
+    ax.set_xlabel("$t$ (ms)")
+    ax.set_ylabel(r"$\Delta t$ (ms)")
 
 with figure("integrate-fire-pif-eest") as fig:
     ax = fig.gca()
@@ -139,7 +139,7 @@ with figure("integrate-fire-pif-eest") as fig:
     ax.axhline(1.0, color="k", ls="--")
     ax.axhline(0.0, color="k", ls="--")
     ax.plot(t[s], eest[s], "ro")
-    ax.set_xlabel("$t$")
+    ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$E_{est}$")
 
 # }}}

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -34,6 +34,11 @@ y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
 tspikes = model.param.constant_spike_times(tfinal, V0=y0[0])
 logger.info("tspike %.8e tstart %.8e, tfinal %.8e", tspikes[0], tstart, tfinal)
+if tspikes.size < 2:
+    raise ValueError(
+        "This example expects at least two spikes. "
+        "Try increasing 'alpha' or 'tfinal'."
+    )
 
 dtinit = 1.0e-1
 c = make_jannelli_controller(
@@ -111,7 +116,8 @@ t_ref = dim.time(t_ref)
 y_ref = dim.var(y_ref)
 tspikes = dim.time(tspikes)
 
-with figure("integrate-fire-pif") as fig:
+basename = f"integrate-fire-pif-{100 * alpha:.0f}"
+with figure(basename) as fig:
     ax = fig.gca()
 
     ax.plot(t, y, lw=3)
@@ -124,7 +130,7 @@ with figure("integrate-fire-pif") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel("$V$ (mV)")
 
-with figure("integrate-fire-pif-dt") as fig:
+with figure(f"{basename}-dt") as fig:
     ax = fig.gca()
 
     ax.semilogy(t[:-1], np.diff(t))
@@ -133,7 +139,7 @@ with figure("integrate-fire-pif-dt") as fig:
     ax.set_xlabel("$t$ (ms)")
     ax.set_ylabel(r"$\Delta t$ (ms)")
 
-with figure("integrate-fire-pif-eest") as fig:
+with figure(f"{basename}-eest") as fig:
     ax = fig.gca()
 
     ax.plot(t, eest)

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -76,16 +76,9 @@ for event in evolve(stepper, dtinit=dtinit):
     elif isinstance(event, StepRejected):
         pass
     else:
-        raise RuntimeError("Evolution failed!")
+        raise RuntimeError(event)
 
-    logger.info(
-        "[%06d] t = %.5e dt = %.5e energy %.5e eest %.5e",
-        event.iteration,
-        event.t,
-        event.dt,
-        event.eest,
-        np.linalg.norm(event.y),
-    )
+    logger.info("%s energy %.5e eest %+.5e", event, np.linalg.norm(event.y), event.eest)
 
 # }}}
 

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -54,8 +54,7 @@ stepper = pif.CaputoPerfectIntegrateFireL1Method(
     derivative_order=(alpha,),
     control=c,
     y0=(y0,),
-    source=model.source,
-    model=model,
+    source=model,
 )
 
 # }}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ multiline-quotes = "double"
 
 [tool.ruff.lint.isort]
 known-first-party = ["pycaputo"]
+force-wrap-aliases = true
 
 [tool.pytest.ini_options]
 testpaths = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ ignore = [
     "PLR0915",  # too-many-statements
     "PLR0917",  # too-many-positional
     "PLR6301",  # no-self-use
+    "PLR6104",  # non-augmented-assignment
     "PLR2004",  # magic-value-comparison
     "S101",     # assert
     "S102",     # exec-builtin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -68,7 +68,7 @@ pygments==2.17.2
     #   rich
 pyparsing==3.1.2
     # via matplotlib
-pyproject-fmt==1.7.0
+pyproject-fmt==1.8.0
 pytest==8.1.1
     # via pytest-benchmark
 pytest-benchmark==4.0.0
@@ -80,7 +80,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 reuse==3.0.2
 rich==13.7.1
-ruff==0.3.5
+ruff==0.4.0
 scipy==1.13.0
 six==1.16.0
     # via python-dateutil
@@ -91,4 +91,4 @@ tomlkit==0.12.4
 types-dataclasses==0.6.6
 typing-extensions==4.11.0
     # via mypy
-uv==0.1.29
+uv==0.1.34

--- a/src/pycaputo/controller.py
+++ b/src/pycaputo/controller.py
@@ -779,7 +779,13 @@ def make_jannelli_controller(
 ) -> JannelliIntegralController:
     r"""Construct a :class:`JannelliIntegralController`.
 
-    This functions simply provides some useful defaults
+    This functions simply provides some useful defaults. The main parameters
+    for the model are the :math:`\chi_{min}` and :math:`\chi_{max}`, which
+    effectively determine the error thresholds at which the step size should
+    change. In general, the rule of thumb is:
+
+    * :math:`\chi_{min}`: smaller values make it harder to increase the step size.
+    * :math:`\chi_{max}`: larger values make it harder to decrease the step size.
 
     :arg sigma: factor by which the time step will be decreased in the case the
         step is rejected. A default value of ``0.5`` will half the time step

--- a/src/pycaputo/history.py
+++ b/src/pycaputo/history.py
@@ -191,8 +191,8 @@ class ProductIntegrationHistory(InMemoryHistory[ProductIntegrationState]):
     """A history for Product Integration methods with variable time step."""
 
     def __getitem__(self, k: int) -> ProductIntegrationState:
-        if k == -1:
-            k = self.filled - 1
+        if k <= -1:
+            k = self.filled + k
 
         if not 0 <= k < self.filled:
             raise IndexError(f"History index out of range: 0 <= {k} < {self.filled}")

--- a/src/pycaputo/integrate_fire/__init__.py
+++ b/src/pycaputo/integrate_fire/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from pycaputo.fode.base import StepRejected, evolve
+from pycaputo.integrate_fire.base import (
+    AdvanceResult,
+    CaputoIntegrateFireL1Method,
+    IntegrateFireModel,
+    ModelT,
+    StepAccepted,
+    estimate_spike_time_linear,
+)
+
+__all__ = (
+    "AdvanceResult",
+    "CaputoIntegrateFireL1Method",
+    "IntegrateFireModel",
+    "ModelT",
+    "StepAccepted",
+    "StepRejected",
+    "estimate_spike_time_linear",
+    "evolve",
+)

--- a/src/pycaputo/integrate_fire/__init__.py
+++ b/src/pycaputo/integrate_fire/__init__.py
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
 # SPDX-License-Identifier: MIT
 
-from pycaputo.fode.base import StepRejected, evolve
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
     CaputoIntegrateFireL1Method,
     IntegrateFireModel,
     ModelT,
     StepAccepted,
+    StepRejected,
     estimate_spike_time_linear,
 )
 
@@ -19,5 +19,4 @@ __all__ = (
     "StepAccepted",
     "StepRejected",
     "estimate_spike_time_linear",
-    "evolve",
 )

--- a/src/pycaputo/integrate_fire/__init__.py
+++ b/src/pycaputo/integrate_fire/__init__.py
@@ -7,6 +7,7 @@ from pycaputo.integrate_fire.base import (
     IntegrateFireModel,
     ModelT,
     StepAccepted,
+    StepFailed,
     StepRejected,
     estimate_spike_time_linear,
 )
@@ -17,6 +18,7 @@ __all__ = (
     "IntegrateFireModel",
     "ModelT",
     "StepAccepted",
+    "StepFailed",
     "StepRejected",
     "estimate_spike_time_linear",
 )

--- a/src/pycaputo/integrate_fire/__init__.py
+++ b/src/pycaputo/integrate_fire/__init__.py
@@ -9,7 +9,6 @@ from pycaputo.integrate_fire.base import (
     StepAccepted,
     StepFailed,
     StepRejected,
-    estimate_spike_time_linear,
 )
 
 __all__ = (
@@ -20,5 +19,4 @@ __all__ = (
     "StepAccepted",
     "StepFailed",
     "StepRejected",
-    "estimate_spike_time_linear",
 )

--- a/src/pycaputo/integrate_fire/__init__.py
+++ b/src/pycaputo/integrate_fire/__init__.py
@@ -3,9 +3,9 @@
 
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
-    CaputoIntegrateFireL1Method,
+    IntegrateFireMethod,
     IntegrateFireModel,
-    ModelT,
+    IntegrateFireModelT,
     StepAccepted,
     StepFailed,
     StepRejected,
@@ -14,9 +14,9 @@ from pycaputo.integrate_fire.base import (
 
 __all__ = (
     "AdvanceResult",
-    "CaputoIntegrateFireL1Method",
+    "IntegrateFireMethod",
     "IntegrateFireModel",
-    "ModelT",
+    "IntegrateFireModelT",
     "StepAccepted",
     "StepFailed",
     "StepRejected",

--- a/src/pycaputo/integrate_fire/ad_ex.py
+++ b/src/pycaputo/integrate_fire/ad_ex.py
@@ -9,7 +9,6 @@ from typing import NamedTuple, overload
 
 import numpy as np
 
-from pycaputo.fode.base import advance
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
@@ -17,6 +16,7 @@ from pycaputo.integrate_fire.base import (
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
+from pycaputo.stepping import advance
 from pycaputo.utils import Array, dc_stringify
 
 logger = get_logger(__name__)

--- a/src/pycaputo/integrate_fire/ad_ex.py
+++ b/src/pycaputo/integrate_fire/ad_ex.py
@@ -611,10 +611,8 @@ def _advance_caputo_ad_ex_l1(  # type: ignore[misc]
     dt: float,
 ) -> AdvanceResult:
     from pycaputo.controller import AdaptiveController
-    from pycaputo.integrate_fire.base import (
-        advance_caputo_integrate_fire_l1,
-        estimate_spike_time_exp,
-    )
+    from pycaputo.integrate_fire.base import advance_caputo_integrate_fire_l1
+    from pycaputo.integrate_fire.spikes import estimate_spike_time_exp
 
     tprev = history.current_time
     t = tprev + dt

--- a/src/pycaputo/integrate_fire/ad_ex.py
+++ b/src/pycaputo/integrate_fire/ad_ex.py
@@ -28,19 +28,19 @@ logger = get_logger(__name__)
 class AdExReference(NamedTuple):
     """Reference variables used to non-dimensionalize the AdEx model."""
 
-    #: Fractional order used to non-dimensionalize.
     alpha: tuple[float, float]
+    """Fractional order used to non-dimensionalize."""
 
-    #: Time scale (in milliseconds: *ms*).
     T_ref: float
-    #: Voltage offset (in millivolts: *mV*).
+    """Time scale (in milliseconds: *ms*)."""
     V_off: float
-    #: Voltage scale (in millivolts: *mV*).
+    """Voltage offset (in millivolts: *mV*)."""
     V_ref: float
-    #: Adaptation variable scale (in picoamperes: *pA*)
+    """Voltage scale (in millivolts: *mV*)."""
     w_ref: float
-    #: Current scale (in picoamperes: *pA*).
+    """Adaptation variable scale (in picoamperes: *pA*)."""
     I_ref: float
+    """Current scale (in picoamperes: *pA*)."""
 
     @overload
     def time(self, t: float) -> float: ...
@@ -61,30 +61,30 @@ class AdExDim(NamedTuple):
     """Dimensional parameters for the Adaptive Exponential Integrate-and-Fire
     (AdEx) model from [Naud2008]_."""
 
-    #: Added current :math:`I` (in picoamperes *pA*).
     current: float
-    #: Total capacitance :math:`C` (in picofarad per millisecond *pF / ms^(alpha - 1)*).
+    """Added current :math:`I` (in picoamperes *pA*)."""
     C: float
-    #: Total leak conductance :math:`g_L` (in nanosiemens *nS*).
+    """Total capacitance :math:`C` (in picofarad per ms *pF / ms^(alpha - 1)*)."""
     gl: float
-    #: Effective rest potential :math:`E_L` (in microvolts *mV*).
+    """Total leak conductance :math:`g_L` (in nanosiemens *nS*)."""
     e_leak: float
-    #: Threshold slope factor :math:`\Delta_T` (in microvolts *mV*).
+    """Effective rest potential :math:`E_L` (in microvolts *mV*)."""
     delta_t: float
-    #: Effective threshold potential :math:`V_T` (in microvolts *mV*).
+    r"""Threshold slope factor :math:`\Delta_T` (in microvolts *mV*)."""
     vt: float
+    """Effective threshold potential :math:`V_T` (in microvolts *mV*)."""
 
-    #: Time constant :math:`\tau_w` (in microseconds *ms^alpha*).
     tau_w: float
-    #: Conductance :math:`a` (in nanosiemens *nS*).
+    r"""Time constant :math:`\tau_w` (in microseconds *ms^alpha*)."""
     a: float
+    """Conductance :math:`a` (in nanosiemens *nS*)."""
 
-    #: Peak potential :math:`V_{peak}` (in microvolts *mV*).
     v_peak: float
-    #: Reset potential :math:`V_r` (in microvolts *mV*).
+    """Peak potential :math:`V_{peak}` (in microvolts *mV*)."""
     v_reset: float
-    #: Adaptation current reset offset :math:`b` (in picoamperes *pA*).
+    """Reset potential :math:`V_r` (in microvolts *mV*)."""
     b: float
+    """Adaptation current reset offset :math:`b` (in picoamperes *pA*)."""
 
     def __str__(self) -> str:
         return dc_stringify(
@@ -159,25 +159,25 @@ class AdExDim(NamedTuple):
 class AdEx(NamedTuple):
     """Non-dimensional parameters for the AdEx model (see :class:`AdExDim`)."""
 
-    #: Reference values used in non-dimensionalization.
     ref: AdExReference
+    """Reference values used in non-dimensionalization."""
 
-    #: Added current :math:`I`.
     current: float
-    #: Effective rest potential :math:`E_L`.
+    """Added current :math:`I`."""
     e_leak: float
+    """Effective rest potential :math:`E_L`."""
 
-    #: Time constant :math:`\tau_w`.
     tau_w: float
-    #: Conductance :math:`a`.
+    r"""Time constant :math:`\tau_w`."""
     a: float
+    """Conductance :math:`a`."""
 
-    #: Peak potential :math:`V_{peak}`.
     v_peak: float
-    #: Reset potential :math:`V_r`.
+    """Peak potential :math:`V_{peak}`."""
     v_reset: float
-    #: Adaptation current reset offset :math:`b`.
+    """Reset potential :math:`V_r`."""
     b: float
+    """Adaptation current reset offset :math:`b`."""
 
     def __str__(self) -> str:
         return dc_stringify(
@@ -421,8 +421,8 @@ class AdExModel(IntegrateFireModel):
         \end{cases}
     """
 
-    #: Non-dimensional parameters for the model.
     param: AdEx
+    """Non-dimensional parameters for the model."""
 
     if __debug__:
 

--- a/src/pycaputo/integrate_fire/ad_ex.py
+++ b/src/pycaputo/integrate_fire/ad_ex.py
@@ -552,8 +552,20 @@ def find_maximum_time_step_lambert(
 
 @dataclass(frozen=True)
 class CaputoAdExIntegrateFireL1Model(CaputoIntegrateFireL1Method[AdExModel]):
+    r"""Implementation of the L1 method for the Adaptive Exponential
+    Integrate-and-Fire model.
+
+    The model is described by :class:`AdExModel` with parameters :class:`AdEx`.
+    """
+
     #: Parameters for the AdEx model.
     model: AdExModel
+
+    @property
+    def order(self) -> float:
+        # NOTE: this is currently not tested, but it should match the PIF/LIF
+        # estimates for the time step even though it does not do the interpolation
+        return 1.0
 
     def solve(self, t: float, y: Array, h: Array, r: Array) -> Array:
         """Solve the implicit equation for the AdEx model.

--- a/src/pycaputo/integrate_fire/ad_ex.py
+++ b/src/pycaputo/integrate_fire/ad_ex.py
@@ -12,7 +12,7 @@ import numpy as np
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
-    CaputoIntegrateFireL1Method,
+    IntegrateFireMethod,
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
@@ -553,7 +553,7 @@ def find_maximum_time_step_lambert(
 
 
 @dataclass(frozen=True)
-class CaputoAdExIntegrateFireL1Model(CaputoIntegrateFireL1Method[AdExModel]):
+class CaputoAdExIntegrateFireL1Model(IntegrateFireMethod[AdExModel]):
     r"""Implementation of the L1 method for the Adaptive Exponential
     Integrate-and-Fire model.
 

--- a/src/pycaputo/integrate_fire/ad_ex.py
+++ b/src/pycaputo/integrate_fire/ad_ex.py
@@ -1,0 +1,535 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import NamedTuple, overload
+
+import numpy as np
+
+from pycaputo.integrate_fire.base import CaputoIntegrateFireL1Method, IntegrateFireModel
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array, dc_stringify
+
+logger = get_logger(__name__)
+
+
+# {{{ parameters
+
+
+class AdExDim(NamedTuple):
+    """Dimensional parameters for the Adaptive Exponential Integrate-and-Fire
+    (AdEx) model from [Naud2008]_."""
+
+    #: Added current :math:`I` (in picoamperes *pA*).
+    current: float
+    #: Total capacitance :math:`C` (in picofarad per millisecond *pF / ms^(alpha - 1)*).
+    c: float
+    #: Total leak conductance :math:`g_L` (in nanosiemens *nS*).
+    gl: float
+    #: Effective rest potential :math:`E_L` (in microvolts *mV*).
+    el: float
+    #: Threshold slope factor :math:`\Delta_T` (in microvolts *mV*).
+    delta_t: float
+    #: Effective threshold potential :math:`V_T` (in microvolts *mV*).
+    vt: float
+
+    #: Time constant :math:`\tau_w` (in microseconds *ms^alpha*).
+    tau_w: float
+    #: Conductance :math:`a` (in nanosiemens *nS*).
+    a: float
+
+    #: Peak potential :math:`V_{peak}` (in microvolts *mV*).
+    v_peak: float
+    #: Reset potential :math:`V_r` (in microvolts *mV*).
+    v_reset: float
+    #: Adaptation current reset offset :math:`b` (in picoamperes *pA*).
+    b: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "I      (current / pA)": self.current,
+                "C      (total capacitance / pF/ms^alpha)": self.c,
+                "g_L    (total leak conductance / nS)": self.gl,
+                "E_L    (effective rest potential / mV)": self.el,
+                "delta_T(threshold slope factor / mV)": self.delta_t,
+                "V_T    (effective threshold potential / mV)": self.vt,
+                "tau_w  (time scale ratio / ms^alpha)": self.tau_w,
+                "a      (conductance / nS)": self.a,
+                "V_peak (peak potential / mV)": self.v_peak,
+                "V_r    (reset potential / mV)": self.v_reset,
+                "b      (adaptation current offset / pA)": self.b,
+            },
+            header=("model", type(self).__name__),
+        )
+
+    def nondim(self, alpha: float | tuple[float, float]) -> AdEx:
+        r"""Construct non-dimensional parameters for the AdEx model.
+
+        The non-dimensionalization is performed using the following rescaling
+
+        .. math::
+
+            \hat{t} = \sqrt[\alpha_1]{\frac{g_L}{C}} t,
+            \qquad
+            \hat{V} = \frac{V - V_T}{\Delta_T},
+            \qquad
+            \hat{w} = \frac{w}{g_L \Delta_T}.
+
+        and results in a reduction of the parameter space to the four
+        non-dimensional variables :math:`(I, E_L, a, \tau_w)` in the model and
+        :math:`(V_{peak}, V_r, b)` in the reset condition.
+
+        :arg alpha: the order of the fractional derivatives for two model
+            components :math:`(V, w)`. These can be the same if the two variables
+            use the same order.
+        """
+        alpha = (alpha, alpha) if isinstance(alpha, float) else alpha
+        if not len(alpha) == 2:
+            raise ValueError(f"Only 2 orders 'alpha' are required: given {len(alpha)}")
+
+        return AdEx(
+            alpha=alpha,
+            T=(self.gl / self.c) ** (1.0 / alpha[0]),
+            current=self.current / (self.delta_t * self.gl),
+            el=(self.el - self.vt) / self.delta_t,
+            tau_w=(self.gl / self.c) ** (alpha[1] / alpha[0]) * self.tau_w,
+            a=self.a / self.gl,
+            v_peak=(self.v_peak - self.vt) / self.delta_t,
+            v_reset=(self.v_reset - self.vt) / self.delta_t,
+            b=self.b / (self.delta_t * self.gl),
+        )
+
+
+class AdEx(NamedTuple):
+    """Non-dimensional parameters for the AdEx model (see :class:`AdExDim`)."""
+
+    #: Fractional orders used in the non-dimensionalization.
+    alpha: tuple[float, float]
+    #: Fractional time scale.
+    T: float
+
+    #: Added current :math:`I`.
+    current: float
+    #: Effective rest potential :math:`E_L`.
+    el: float
+
+    #: Time constant :math:`\tau_w`.
+    tau_w: float
+    #: Conductance :math:`a`.
+    a: float
+
+    #: Peak potential :math:`V_{peak}`.
+    v_peak: float
+    #: Reset potential :math:`V_r`.
+    v_reset: float
+    #: Adaptation current reset offset :math:`b`.
+    b: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "alpha  (fractional order)": self.alpha,
+                "T      (fractional time scale)": self.T,
+                "I      (current)": self.current,
+                "E_L    (effective rest potential)": self.el,
+                "tau_w  (time scale ratio)": self.tau_w,
+                "a      (conductance)": self.a,
+                "V_peak (peak potential)": self.v_peak,
+                "V_r    (reset potential)": self.v_reset,
+                "b      (adaptation current offset)": self.b,
+            },
+            header=("model", type(self).__name__),
+        )
+
+
+# Parameter values for the integer-order system from [Naud2008]_ Table 1.
+AD_EX_PARAMS: dict[str, AdExDim] = {
+    "Naud4a": AdExDim(
+        c=200,
+        gl=10,
+        el=-70,
+        vt=-50,
+        delta_t=2,
+        a=2,
+        tau_w=30,
+        b=0,
+        v_reset=-58,
+        v_peak=0.0,
+        current=500,
+    ),
+    "Naud4b": AdExDim(
+        c=200,
+        gl=12,
+        el=-70,
+        vt=-50,
+        delta_t=2,
+        a=2,
+        tau_w=300,
+        b=60,
+        v_reset=-58,
+        v_peak=0.0,
+        current=500,
+    ),
+    "Naud4c": AdExDim(
+        c=130,
+        gl=18,
+        el=-58,
+        vt=-50,
+        delta_t=2,
+        a=4,
+        tau_w=150,
+        b=120,
+        v_reset=-50,
+        v_peak=0.0,
+        current=400,
+    ),
+    "Naud4d": AdExDim(
+        c=200,
+        gl=10,
+        el=-58,
+        vt=-50,
+        delta_t=2,
+        a=2,
+        tau_w=120,
+        b=100,
+        v_reset=-46,
+        v_peak=0.0,
+        current=210,
+    ),
+    "Naud4e": AdExDim(
+        c=200,
+        gl=12,
+        el=-70,
+        vt=-50,
+        delta_t=2,
+        a=-10,
+        tau_w=300,
+        b=0,
+        v_reset=-58,
+        v_peak=0.0,
+        current=300,
+    ),
+    "Naud4f": AdExDim(
+        c=200,
+        gl=12,
+        el=-70,
+        vt=-50,
+        delta_t=2,
+        a=-6,
+        tau_w=300,
+        b=0,
+        v_reset=-58,
+        v_peak=0.0,
+        current=110,
+    ),
+    "Naud4g": AdExDim(
+        c=100,
+        gl=10,
+        el=-65,
+        vt=-50,
+        delta_t=2,
+        a=-10,
+        tau_w=90,
+        b=30,
+        v_reset=-47,
+        v_peak=0.0,
+        current=350,
+    ),
+    "Naud4h": AdExDim(
+        c=100,
+        gl=12,
+        el=-60,
+        vt=-50,
+        delta_t=2,
+        a=-11,
+        tau_w=130,
+        b=30,
+        v_reset=-48,
+        v_peak=0.0,
+        current=160,
+    ),
+}
+
+
+@overload
+def get_ad_ex_parameters(name: str, alpha: float | tuple[float, float]) -> AdEx: ...
+
+
+@overload
+def get_ad_ex_parameters(name: str, alpha: None = None) -> AdExDim: ...
+
+
+def get_ad_ex_parameters(
+    name: str, alpha: float | tuple[float, float] | None = None
+) -> AdEx | AdExDim:
+    """Get a set of known parameters for the AdEx model.
+
+    The following parameters are available:
+
+    * From [Naud2008]_ Table 1: sets are named ``NaudXX``, where the suffix
+      corresponds to the figure number, e.g. ``Naud4a`` to ``Naud4h``.
+
+    :arg name: a parameter set name.
+    :arg alpha: the order of the fractional derivative.
+
+    :returns: a set of non-dimensional parameters if *alpha* is given, otherwise
+        the dimensional parameters are returned (see :class:`AdExDim`).
+    """
+    if name not in AD_EX_PARAMS:
+        raise ValueError(
+            "Unknown parameter set '{}'. Known values are '{}'".format(
+                name, "', '".join(AD_EX_PARAMS)
+            )
+        )
+
+    if alpha is None:
+        return AD_EX_PARAMS[name]
+
+    return AD_EX_PARAMS[name].nondim(alpha)
+
+
+def get_ad_ex_parameters_latex(alpha: float | tuple[float, float]) -> str:
+    from rich.box import Box
+    from rich.table import Table
+
+    box = Box("    \n  &\\\n    \n  &\\\n    \n    \n  &\\\n    \n")
+    t = Table(
+        *[
+            "Name",
+            "$E_L$",
+            "$a$",
+            r"$\tau_w$",
+            "$b$",
+            "$V_r$",
+            "$I$",
+        ],
+        box=box,
+        header_style=None,
+    )
+
+    for name, param in AD_EX_PARAMS.items():
+        ad_ex = param.nondim(alpha)
+        t.add_row(*[
+            name,
+            f"{ad_ex.el:.3f}",
+            f"{ad_ex.a:.3f}",
+            f"{ad_ex.tau_w:.3f}",
+            f"{ad_ex.b:.3f}",
+            f"{ad_ex.v_reset:.3f}",
+            f"{ad_ex.current:.3f}",
+        ])
+
+    from rich.console import Console
+
+    output = io.StringIO()
+    c = Console(file=output)
+
+    c.print(r"\begin{tabular}{llllll}\toprule")
+    c.print(t)
+    c.print("")
+
+    return output.getvalue()
+
+
+# }}}
+
+
+# {{{ AdEx model
+
+
+@dataclass(frozen=True)
+class AdExModel(IntegrateFireModel):
+    r"""Functionals for the AdEx model of [Naud2008]_ with parameters :class:`AdEx`.
+
+    .. math::
+
+        \left\{
+        \begin{aligned}
+        \frac{\mathrm{d}^{\alpha_1} V}{\mathrm{d} t^{\alpha_1}} & =
+        I(t) - (V - E_L) + \exp(V) - w, \\
+        \tau_w \frac{\mathrm{d}^{\alpha_2} w}{\mathrm{d} t^{\alpha_2}} & =
+            a (V - E_L) - w
+        \end{aligned}
+        \right.
+
+    where :math:`I` is taken to be constant. The reset condition is given by
+
+    .. math::
+
+        \text{if } V > V_{peak} \qquad \text{then} \qquad
+        \begin{cases}
+        V \gets V_r, \\
+        w \gets w + b.
+        \end{cases}
+    """
+
+    #: Non-dimensional parameters for the model.
+    param: AdEx
+
+    if __debug__:
+
+        def __post_init__(self) -> None:
+            if not isinstance(self.param, AdEx):
+                raise TypeError(
+                    f"Invalid parameter type: '{type(self.param).__name__}'"
+                )
+
+    def source(self, t: float, y: Array) -> Array:
+        """Evaluate right-hand side of the AdEx model."""
+        V, w = y
+        p = self.param
+
+        return np.array([
+            p.current - (V - p.el) + np.exp(V) - w,
+            (p.a * (V - p.el) - w) / p.tau_w,
+        ])
+
+    def source_jac(self, t: float, y: Array) -> Array:
+        """Evaluate the Jacobian of the right-hand side of the AdEx model."""
+        V, _ = y
+        p = self.param
+
+        # J_{ij} = d f_i / d y_j
+        return np.array([
+            [-1.0 + np.exp(V), -1.0],
+            [p.a / p.tau_w, -1.0 / p.tau_w],
+        ])
+
+    def spiked(self, t: float, y: Array) -> float:
+        """Compute a delta from the peak threshold :math:`V_{peak}`.
+
+        :returns: a delta of :math:`V - V_{peak}` that can be used to determine
+            if the neuron spiked.
+        """
+        V, _ = y
+        return float(V - self.param.v_peak)
+
+    def reset(self, t: float, y: Array) -> Array:
+        r"""Evaluate the reset values at :math:`(t, V, w)`.
+
+        This function assumes that the :math:`V \ge V_{peak}`, so that a spike-reset
+        is valid. If this is not the case, the reset is obviously not valid.
+        """
+        # TODO: should this be a proper check?
+        assert self.spiked(t, y) > -10.0 * np.finfo(y.dtype).eps
+
+        _, w = y
+        return np.array([self.param.v_reset, w + self.param.b])
+
+
+# }}}
+
+
+# {{{ Lambert W solver
+
+
+class _PotentialCoefficient(NamedTuple):
+    d0: float
+    d1: float
+    d2: float
+
+
+class _AdaptationCoefficient(NamedTuple):
+    c0: float
+    c1: float
+
+
+def _evaluate_lambert_coefficients(
+    ad_ex: AdExModel, h: Array, r: Array
+) -> tuple[_PotentialCoefficient, _AdaptationCoefficient]:
+    # NOTE: small rename to match write-up
+    hV, hw = h
+    rV, rw = r
+    _, _, I, el, tau_w, a, *_ = ad_ex.param  # noqa: E741
+
+    # w coefficients: w = c0 V + c1
+    c0 = a * hw / (tau_w + hw)
+    c1 = (tau_w * rw - a * hw * el) / (hw + tau_w)
+
+    # V coefficients: d0 V + d1 = d2 exp(V)
+    d0 = 1 + hV * (1 + c0)
+    d1 = -hV * (I + el - c1) - rV
+    d2 = hV
+
+    return _PotentialCoefficient(d0, d1, d2), _AdaptationCoefficient(c0, c1)
+
+
+def _find_maximum_time_lambert(ad_ex: AdExModel, t: float, r: Array) -> float:
+    from math import gamma
+
+    def func(tspike: float) -> float:
+        alpha = ad_ex.param.alpha
+        h = np.array([
+            gamma(2 - alpha[0]) * (tspike - t) ** alpha[0],
+            gamma(2 - alpha[1]) * (tspike - t) ** alpha[1],
+        ])
+
+        (d0, d1, d2), _ = _evaluate_lambert_coefficients(ad_ex, h, r)
+        return float(d2 / d0 * np.exp(-d1 / d0 + 1.0)) - 1.0
+
+    import scipy.optimize as so
+
+    try:
+        result = so.root_scalar(
+            f=func,
+            x0=1.0e-2,
+            bracket=[0.0, 0.5],
+        )
+        return float(result.root)
+    except ValueError:
+        # FIXME: what's a good return value here? the calling code should have
+        # a `dt = min(dt_min, t_min - t)` to handle any large values
+        return 0.5
+
+
+# }}}
+
+
+# {{{ AdExIntegrateFireL1Method
+
+
+def ad_ex_solve(ad_ex: AdExModel, t: float, y0: Array, h: Array, r: Array) -> Array:
+    r"""Solve the implicit equation for the AdEx model.
+
+    This solve an implicit nonlinear equation of the form
+
+    .. math::
+
+        \mathbf{y} - \mathbf{h} \odot \mathbf{f}(t, \mathbf{y}) = \mathbf{r}
+
+    where :math:`\mathbf{f}` is given by the source term of the :class:`AdExModel`.
+    In that case, we can solve the equation explicitly, i.e. without an iterative
+    method, by using the Lambert W function.
+
+    This function can return complex results if the solution is out of range of
+    the Lambert W function. This can happen if the simulation becomes unstable
+    or it is close to a spike and the time step is too large.
+
+    See :func:`pycaputo.implicit.solve` for an interactive method based on the
+    :func:`scipy.optimize.root`.
+    """
+
+    from scipy.special import lambertw
+
+    d, c = _evaluate_lambert_coefficients(ad_ex, h, r)
+    dstar = -d[2] / d[0] * np.exp(-d[1] / d[0])
+    Vstar = -d[1] / d[0] - lambertw(dstar)
+    wstar = c[0] * Vstar + c[1]
+
+    return np.array([Vstar, wstar])
+
+
+@dataclass(frozen=True)
+class AdExIntegrateFireL1Method(CaputoIntegrateFireL1Method[AdExModel]):
+    #: Parameters for the AdEx model.
+    model: AdExModel
+
+    def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
+        return ad_ex_solve(self.model, t, y0, c, r)
+
+
+# }}}

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -17,7 +17,12 @@ from pycaputo.fode.base import (
     evolve,
     make_initial_condition,
 )
-from pycaputo.fode.base import StepAccepted as StepAcceptedBase
+from pycaputo.fode.base import (
+    StepAccepted as StepAcceptedBase,
+)
+from pycaputo.fode.base import (
+    StepRejected as StepRejectedBase,
+)
 from pycaputo.history import History, ProductIntegrationHistory
 from pycaputo.logging import get_logger
 from pycaputo.utils import Array
@@ -70,6 +75,11 @@ ModelT = TypeVar("ModelT", bound=IntegrateFireModel)
 class StepAccepted(StepAcceptedBase):
     #: A flag to denote if the current accepted step was due to a spike.
     spiked: bool
+
+
+@dataclass(frozen=True)
+class StepRejected(StepRejectedBase):
+    pass
 
 
 class AdvanceResult(NamedTuple):

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -1,0 +1,450 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Any, Generic, Iterator, NamedTuple, TypeVar
+
+import numpy as np
+
+from pycaputo.derivatives import CaputoDerivative, Side
+from pycaputo.fode.base import (
+    Event,
+    FractionalDifferentialEquationMethod,
+    evolve,
+    make_initial_condition,
+)
+from pycaputo.fode.base import StepAccepted as StepAcceptedBase
+from pycaputo.history import History, ProductIntegrationHistory
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array
+
+logger = get_logger(__name__)
+
+# {{{ model interface
+
+
+class IntegrateFireModel(ABC):
+    @abstractmethod
+    def source(self, t: float, y: Array) -> Array:
+        """Evaluate the right-hand side of the IF model."""
+
+    @abstractmethod
+    def source_jac(self, t: float, y: Array) -> Array:
+        """Evaluate the Jacobian of the right-hand side of the IF model."""
+
+    @abstractmethod
+    def spiked(self, t: float, y: Array) -> float:
+        """Check if the neuron has spiked.
+
+        In most cases, this will simply be a delta of :math:`V - V_{peak}`, but
+        it is generally left to the model itself to define how the spike is
+        recognized.
+
+        :returns: a positive value if the neuron spiked and a negative value
+            otherwise.
+        """
+
+    @abstractmethod
+    def reset(self, t: float, y: Array) -> Array:
+        """Evaluate the reset values for the IF model.
+
+        This function assumes that the neuron has spiked, i.e. that :meth:`spiked`
+        returns a non-negative value. If this is not the case, the reset should
+        not be applied.
+        """
+
+
+ModelT = TypeVar("ModelT", bound=IntegrateFireModel)
+
+# }}}
+
+
+# {{{ method
+
+
+@dataclass(frozen=True)
+class StepAccepted(StepAcceptedBase):
+    #: A flag to denote if the current accepted step was due to a spike.
+    spiked: bool
+
+
+class AdvanceResult(NamedTuple):
+    """Result of :func:`~pycaputo.fode.advance` for
+    :class:`CaputoIntegrateFireL1Method` subclasses.
+    """
+
+    #: Estimated solution at the next time step.
+    y: Array
+    #: Estimated truncation error at the next time step.
+    trunc: Array
+    #: Array to add to the history storage.
+    storage: Array
+
+    #: Flag to denote if a spike occurred.
+    spiked: Array
+    #: Time step taken by the method in case a spike occurred.
+    dts: Array
+
+
+@dataclass(frozen=True)
+class CaputoIntegrateFireL1Method(
+    FractionalDifferentialEquationMethod, Generic[ModelT]
+):
+    r"""An implicit discretization of the Caputo derivative for Integrate-and-Fire
+    models based on the L1 method.
+
+    A generic leaky Integrate-and-Fire model is given by
+
+    .. math::
+
+        D_C^\alpha[\mathbf{y}](t) = \mathbf{f}(t, \mathbf{y})
+
+    together with a reset condition of the form
+
+    .. math::
+
+        \text{condition}(t, \mathbf{y}) \ge 0
+        \quad \text{then} \quad
+        \mathbf{y} = \text{reset}(t, \mathbf{y}),
+
+    where the ``condition`` function and the ``reset`` functions are provided
+    by the user. For example, if we assume that our model has two variables
+    :math:`(V, w)` and we want to model the reset condition
+
+    .. math::
+
+        V \ge V_{peak} \quad \text{then} \quad
+        \begin{cases}
+        V \gets V_r, \\
+        w \gets w + b,
+        \end{cases}
+
+    we can set
+
+    .. math::
+
+        \begin{cases}
+        \text{condition}(t, [V, w]) = V - V_{peak}, \\
+        \text{reset}(t, [V, w]) = (V_r, w + b)
+        \end{cases}
+
+    for certain coefficients :math:`V_{peak}, V_r` and :math:`b`. These can
+    be very general conditions. The variant of the L1 method implemented here
+    takes into account the inherent discontinuity of the solutions to this
+    type of equation (see :class:`~pycaputo.differentiation.CaputoL1Method`
+    for a smooth implementation).
+    """
+
+    #: Integrate-and-Fire model parameters and functions.
+    model: ModelT
+
+    @cached_property
+    def d(self) -> tuple[CaputoDerivative, ...]:
+        return tuple([
+            CaputoDerivative(order=alpha, side=Side.Left)
+            for alpha in self.derivative_order
+        ])
+
+    @property
+    def order(self) -> float:
+        # FIXME: this is the same as the standard L1 method? Unlikely..
+        return 2.0 - self.largest_derivative_order
+
+    def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
+        """Wrapper around :func:`pycaputo.implicit.solve` to solve the implicit
+        equation.
+
+        This function should be overwritten for specific applications if better
+        solvers are known. For example, many problems can be solved explicitly
+        or approximated to a very good degree to provide a better *y0*.
+        """
+        raise NotImplementedError(type(self).__name__)
+
+
+@make_initial_condition.register(CaputoIntegrateFireL1Method)
+def _make_initial_condition_caputo(m: CaputoIntegrateFireL1Method[ModelT]) -> Array:
+    return m.y0[0]
+
+
+@evolve.register(CaputoIntegrateFireL1Method)
+def _evolve_caputo_integrate_fire_l1(
+    m: CaputoIntegrateFireL1Method[ModelT],
+    *,
+    history: History[Any] | None = None,
+    dtinit: float | None = None,
+) -> Iterator[Event]:
+    from pycaputo.controller import (
+        StepEstimateError,
+        estimate_initial_time_step,
+        evaluate_error_estimate,
+        evaluate_timestep_accept,
+        evaluate_timestep_factor,
+        evaluate_timestep_reject,
+    )
+    from pycaputo.fode.base import StepFailed, StepRejected, advance
+
+    if history is None:
+        history = ProductIntegrationHistory.empty_like(np.hstack([m.y0[0], m.y0[0]]))
+
+    # initialize
+    c = m.control
+    n = 0
+    t = c.tstart
+
+    # determine initial condition
+    yprev = make_initial_condition(m)
+    history.append(t, np.hstack([yprev, yprev]))
+
+    # determine initial time step
+    if dtinit is None:
+        dtinit = estimate_initial_time_step(
+            t, yprev, m.source, m.smallest_derivative_order, trunc=m.order + 1
+        )
+
+    dt = dtinit
+    yield StepAccepted(
+        t=t,
+        iteration=n,
+        dt=dt,
+        y=yprev,
+        eest=0.0,
+        q=1.0,
+        trunc=np.zeros_like(yprev),
+        spiked=False,
+    )
+
+    while not c.finished(n, t):
+        # evolve solution with current estimate of the time step
+        result = advance(m, history, yprev, dt)
+
+        assert isinstance(result, AdvanceResult)
+        ynext, trunc, storage = result[:3]
+
+        # determine the next time step
+        if result.spiked:
+            # NOTE: a spike occurred, so we reset everything
+            dtnext = dtinit
+            accepted = True
+            eest = 0.0
+            q = 1.0
+        else:
+            try:
+                # estimate error
+                eest = evaluate_error_estimate(c, m, trunc, ynext, yprev)
+                accepted = eest <= 1.0
+
+                # estimate time step factor using the error
+                q = evaluate_timestep_factor(c, m, eest)
+
+                # finally estimate a good dt for the next step
+                tmp_state = {"t": t, "n": n, "y": yprev}
+                if accepted:
+                    dtnext = evaluate_timestep_accept(c, m, q, dt, tmp_state)
+                else:
+                    dtnext = evaluate_timestep_reject(c, m, q, dt, tmp_state)
+            except StepEstimateError as exc:
+                accepted = False
+                dtnext = 1.0e-6
+                logger.error("Failed to estimate timestep.", exc_info=exc)
+                yield StepFailed(t=t, iteration=n, reason="Failed to estimate timestep")
+
+        assert dtnext >= 0.0
+
+        # update variables
+        assert result.dts >= 0
+        if eest <= 1.0:
+            dt = float(result.dts)
+
+            n += 1
+            t += dt
+            yprev = ynext
+            history.append(t, storage)
+
+            if result.spiked:
+                # NOTE: if we spiked, also yield the value before the
+                # discontinuity so that the plots look nice!
+                yield StepAccepted(
+                    t=t,
+                    iteration=n,
+                    dt=dt,
+                    y=storage[: ynext.size],
+                    eest=eest,
+                    q=q,
+                    trunc=trunc,
+                    spiked=bool(result.spiked),
+                )
+
+                # NOTE: we need to increment the iteration, but not the time
+                # because both values in the spike happen at the same time due
+                # to the discontinuity
+                n += 1
+
+            yield StepAccepted(
+                t=t,
+                iteration=n,
+                dt=dt,
+                y=ynext,
+                eest=eest,
+                q=q,
+                trunc=trunc,
+                # NOTE: if we spiked on this step, the previous value will
+                # record it so we don't need to do it twice.
+                spiked=False,
+            )
+        else:
+            yield StepRejected(
+                t=t, iteration=n, dt=dt, y=ynext, eest=eest, q=q, trunc=trunc
+            )
+
+        dt = dtnext
+
+
+def advance_caputo_integrate_fire_l1(
+    m: CaputoIntegrateFireL1Method[ModelT],
+    history: ProductIntegrationHistory,
+    y: Array,
+    dt: float,
+) -> AdvanceResult:
+    # set next time step
+    d = y.size
+    n = len(history)
+    t = history.ts[n] = history.ts[n - 1] + dt
+
+    # get time history
+    ts = history.ts[n] - history.ts[: n + 1]
+
+    # compute convolution coefficients
+    alpha = m.alpha.reshape(-1, 1)
+    gamma2m = m.gamma2m.reshape(-1, 1)
+
+    omega = (ts[:-1] ** (1 - alpha) - ts[1:] ** (1 - alpha)) / gamma2m
+    h = (omega / np.diff(history.ts[: n + 1])).T
+    assert h.shape == (n, d)
+
+    # NOTE: we store (t_k, [y^-_k, y^+_k]) at every time step and want to compute
+    #   h_{n + 1, k} (y^-_{k + 1} - y^+_k)
+    dy = history.storage[1 : n + 1, :d] - history.storage[:n, d:]
+    r = np.einsum("ij,ij->j", h[:-1], dy[:-1])
+
+    from pycaputo.fode.caputo import _truncation_error
+
+    ynext = m.solve(t, y, 1 / h[-1], y - r / h[-1])
+    trunc = _truncation_error(m.control, m.alpha, t, ynext, t - dt, y)
+
+    return AdvanceResult(
+        ynext, trunc, np.hstack([ynext, ynext]), spiked=np.array(0), dts=np.array(dt)
+    )
+
+
+# }}}
+
+
+# {{{ spike time
+
+
+def estimate_spike_time_linear(
+    t: float, V: Array, tprev: float, Vprev: Array, Vpeak: Array | float
+) -> float:
+    """Give a linear estimation of the spike time.
+
+    .. math::
+
+        V(t) = a + b t.
+
+    We assume that the spike occurred between :math:`(t, V)` and
+    :math:`(t_{prev}, V_{prev})` at :math:`V_{peak}`. This information can be
+    used to provide a simple linear estimation for the spike time.
+
+    :return: an estimation of the spike time.
+    """
+    assert Vprev <= Vpeak <= V
+    ts = (Vpeak - Vprev) / (V - Vprev) * t + (V - Vpeak) / (V - Vprev) * tprev
+    assert tprev <= ts <= t
+
+    return float(ts)
+
+
+def advance_caputo_integrate_fire_spike_linear(
+    tprev: float,
+    y: Array,
+    t: float,
+    result: AdvanceResult,
+    *,
+    v_peak: float,
+    v_reset: float,
+) -> AdvanceResult:
+    # we have spiked, so we need to reconstruct our solution
+    yprev = np.array([v_peak], dtype=y.dtype)
+    ynext = np.array([v_reset], dtype=y.dtype)
+
+    # estimate the time step used to get here
+    ts = estimate_spike_time_linear(t, result.y[0], tprev, y[0], v_peak)
+    dt = float(ts - tprev)
+
+    # set the truncation error to zero because we want to reset the next time
+    # step to the maximum allowable value.
+    trunc = np.zeros_like(y)
+
+    return AdvanceResult(
+        ynext, trunc, np.hstack([yprev, ynext]), spiked=np.array(1), dts=np.array(dt)
+    )
+
+
+def estimate_spike_time_exp(
+    t: float, V: Array, tprev: float, Vprev: Array, Vpeak: Array | float
+) -> float:
+    """Give an exponential estimation of the spike time.
+
+    .. math::
+
+        V(t) = a b^t.
+
+    :returns: an estimate of the spike time.
+    """
+    assert Vprev <= Vpeak <= V
+    b = (V / Vprev) ** (1 / (t - tprev))
+    ts = tprev + (np.log(Vpeak) - np.log(Vprev)) / np.log(b)
+
+    assert tprev <= ts <= t
+    return float(ts)
+
+
+def advance_caputo_integrate_fire_spike_exp(
+    tprev: float,
+    y: Array,
+    t: float,
+    result: AdvanceResult,
+    *,
+    v_peak: float,
+    v_reset: float,
+) -> AdvanceResult:
+    # we have spiked, so we need to reconstruct our solution
+    yprev = np.array([v_peak], dtype=y.dtype)
+    ynext = np.array([v_reset], dtype=y.dtype)
+
+    if np.any(np.iscomplex(result.y)):
+        # keep the time step estimate the same here, because we can't really
+        # do better at this time. maybe solve the Lambert W equation?
+        dt = float(result.dts)
+
+        # set the truncation error to a large value to reject the next time step
+        trunc = np.full_like(y, 1.0e5)
+    else:
+        # estimate the time step used to get here
+        ts = estimate_spike_time_exp(t, result.y[0], tprev, y[0], v_peak)
+        dt = float(ts - tprev)
+
+        # set the truncation error to zero because we want to reset the next time
+        # step to the maximum allowable value.
+        trunc = np.zeros_like(y)
+
+    return AdvanceResult(
+        ynext, trunc, np.hstack([yprev, ynext]), spiked=np.array(1), dts=np.array(dt)
+    )
+
+
+# }}}

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -352,7 +352,11 @@ def advance_caputo_integrate_fire_l1(
     trunc = _truncation_error(m.control, m.alpha, t, ynext, t - dt, y)
 
     result = AdvanceResult(
-        ynext, trunc, np.hstack([ynext, ynext]), spiked=np.array(0), dts=np.array(dt)
+        ynext,
+        trunc,
+        np.hstack([ynext, ynext]),
+        spiked=np.array(0),
+        dts=np.array(dt),
     )
 
     return result, r

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -152,6 +152,13 @@ class CaputoIntegrateFireL1Method(
     #: Integrate-and-Fire model parameters and functions.
     model: ModelT
 
+    if __debug__:
+
+        def __post_init__(self) -> None:
+            super().__post_init__()
+            if any(a > 1.0 or a < 0.0 for a in self.derivative_order):
+                raise ValueError(f"Expected 'alpha' in (0, 1): {self.derivative_order}")
+
     @cached_property
     def d(self) -> tuple[CaputoDerivative, ...]:
         return tuple([
@@ -161,8 +168,7 @@ class CaputoIntegrateFireL1Method(
 
     @property
     def order(self) -> float:
-        # FIXME: this is the same as the standard L1 method? Unlikely..
-        return 2.0 - self.largest_derivative_order
+        return 1.0
 
     def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
         """Wrapper around :func:`pycaputo.implicit.solve` to solve the implicit

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -366,29 +366,7 @@ def advance_caputo_integrate_fire_l1(
 # }}}
 
 
-# {{{ spike time
-
-
-def estimate_spike_time_linear(
-    t: float, V: Array, tprev: float, Vprev: Array, Vpeak: Array | float
-) -> float:
-    """Give a linear estimation of the spike time.
-
-    .. math::
-
-        V(t) = a + b t.
-
-    We assume that the spike occurred between :math:`(t, V)` and
-    :math:`(t_{prev}, V_{prev})` at :math:`V_{peak}`. This information can be
-    used to provide a simple linear estimation for the spike time.
-
-    :return: an estimation of the spike time.
-    """
-    assert Vprev <= Vpeak <= V
-    ts = (Vpeak - Vprev) / (V - Vprev) * t + (V - Vpeak) / (V - Vprev) * tprev
-    assert tprev <= ts <= t
-
-    return float(ts)
+# {{{ advance helpers
 
 
 def advance_caputo_integrate_fire_spike_linear(
@@ -400,6 +378,8 @@ def advance_caputo_integrate_fire_spike_linear(
     v_peak: float,
     v_reset: float,
 ) -> AdvanceResult:
+    from pycaputo.integrate_fire.spikes import estimate_spike_time_linear
+
     # we have spiked, so we need to reconstruct our solution
     yprev = np.array([v_peak], dtype=y.dtype)
     ynext = np.array([v_reset], dtype=y.dtype)
@@ -415,25 +395,6 @@ def advance_caputo_integrate_fire_spike_linear(
     return AdvanceResult(
         ynext, trunc, np.hstack([yprev, ynext]), spiked=np.array(1), dts=np.array(dt)
     )
-
-
-def estimate_spike_time_exp(
-    t: float, V: Array, tprev: float, Vprev: Array, Vpeak: Array | float
-) -> float:
-    """Give an exponential estimation of the spike time.
-
-    .. math::
-
-        V(t) = a b^t.
-
-    :returns: an estimate of the spike time.
-    """
-    assert Vprev <= Vpeak <= V
-    b = (V / Vprev) ** (1 / (t - tprev))
-    ts = tprev + (np.log(Vpeak) - np.log(Vprev)) / np.log(b)
-
-    assert tprev <= ts <= t
-    return float(ts)
 
 
 # }}}

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -65,8 +65,8 @@ class IntegrateFireModel(ABC):
         return self.source(t, y)
 
 
-#: An invariant :class:`~typing.TypeVar` bound to :class:`IntegrateFireModel`.
 IntegrateFireModelT = TypeVar("IntegrateFireModelT", bound=IntegrateFireModel)
+"""An invariant :class:`~typing.TypeVar` bound to :class:`IntegrateFireModel`."""
 
 # }}}
 
@@ -81,8 +81,8 @@ class StepFailed(events.StepFailed):
 
 @dataclass(frozen=True)
 class StepAccepted(events.StepAccepted):
-    #: A flag to denote if the current accepted step was due to a spike.
     spiked: bool
+    """A flag to denote if the current accepted step was due to a spike."""
 
 
 @dataclass(frozen=True)
@@ -95,17 +95,17 @@ class AdvanceResult(NamedTuple):
     subclasses.
     """
 
-    #: Estimated solution at the next time step.
     y: Array
-    #: Estimated truncation error at the next time step.
+    """Estimated solution at the next time step."""
     trunc: Array
-    #: Array to add to the history storage.
+    """Estimated truncation error at the next time step."""
     storage: Array
+    """Array to add to the history storage."""
 
-    #: Flag to denote if a spike occurred.
     spiked: Array
-    #: Time step taken by the method in case a spike occurred.
+    """Flag to denote if a spike occurred."""
     dts: Array
+    """Time step taken by the method in case a spike occurred."""
 
 
 @dataclass(frozen=True)

--- a/src/pycaputo/integrate_fire/eif.py
+++ b/src/pycaputo/integrate_fire/eif.py
@@ -8,7 +8,6 @@ from typing import NamedTuple, overload
 
 import numpy as np
 
-from pycaputo.fode.base import advance
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
@@ -16,6 +15,7 @@ from pycaputo.integrate_fire.base import (
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
+from pycaputo.stepping import advance
 from pycaputo.utils import Array, dc_stringify
 
 logger = get_logger(__name__)

--- a/src/pycaputo/integrate_fire/eif.py
+++ b/src/pycaputo/integrate_fire/eif.py
@@ -26,17 +26,17 @@ logger = get_logger(__name__)
 class EIFReference(NamedTuple):
     """Reference variables used to non-dimensionalize the EIF model."""
 
-    #: Fractional order used to non-dimensionalize.
     alpha: float
+    """Fractional order used to non-dimensionalize."""
 
-    #: Time scale (in milliseconds: *ms*).
     T_ref: float
-    #: Voltage offset (in millivolts: *mV*).
+    """Time scale (in milliseconds: *ms*)."""
     V_off: float
-    #: Voltage scale (in millivolts: *mV*).
+    """Voltage offset (in millivolts: *mV*)."""
     V_ref: float
-    #: Current scale (in picoamperes: *pA*).
+    """Voltage scale (in millivolts: *mV*)."""
     I_ref: float
+    """Current scale (in picoamperes: *pA*)."""
 
     @overload
     def time(self, t: float) -> float: ...
@@ -56,23 +56,23 @@ class EIFReference(NamedTuple):
 class EIFDim(NamedTuple):
     """Dimensional parameters for the Exponential Integrate-and-Fire (EIF) model."""
 
-    #: Added current :math:`I` (in picoamperes *pA*).
     current: float
-    #: Total capacitance :math:`C` (in picofarad per millisecond *pF / ms^(alpha - 1)*).
+    """Added current :math:`I` (in picoamperes *pA*)."""
     C: float
-    #: Total leak conductance :math:`g_L` (in nanosiemens *nS*).
+    """Total capacitance :math:`C` (in picofarad per ms *pF / ms^(alpha - 1)*)."""
     gl: float
-    #: Equilibrium potential leak :math:`E_L` (in microvolts *mV*).
+    """Total leak conductance :math:`g_L` (in nanosiemens *nS*)."""
     e_leak: float
-    #: Threshold slope factor :math:`\Delta_T` (in microvolts *mV*).
+    """Equilibrium potential leak :math:`E_L` (in microvolts *mV*)."""
     delta_t: float
-    #: Effective threshold potential :math:`V_T` (in microvolts *mV*).
+    r"""Threshold slope factor :math:`\Delta_T` (in microvolts *mV*)."""
     vt: float
+    """Effective threshold potential :math:`V_T` (in microvolts *mV*)."""
 
-    #: Peak potential :math:`V_{peak}` (in millivolts: *mV*).
     v_peak: float
-    #: Reset potential :math:`V_r` (in millivolts: *mV*).
+    """Peak potential :math:`V_{peak}` (in millivolts: *mV*)."""
     v_reset: float
+    """Reset potential :math:`V_r` (in millivolts: *mV*)."""
 
     def __str__(self) -> str:
         return dc_stringify(
@@ -132,18 +132,18 @@ class EIFDim(NamedTuple):
 class EIF(NamedTuple):
     """Non-dimensional parameters for the EIF model (see :class:`EIFDim`)."""
 
-    #: Reference values used in non-dimensionalization.
     ref: EIFReference
+    """Reference values used in non-dimensionalization."""
 
-    #: Current :math:`I`.
     current: float
-    #: Equilibrium potential leak :math:`E_L`.
+    """Current :math:`I`."""
     e_leak: float
+    """Equilibrium potential leak :math:`E_L`."""
 
-    #: Peak potential :math:`V_{peak}`.
     v_peak: float
-    #: Reset potential :math:`V_r`.
+    """Peak potential :math:`V_{peak}`."""
     v_reset: float
+    """Reset potential :math:`V_r`."""
 
     def __str__(self) -> str:
         return dc_stringify(
@@ -173,8 +173,8 @@ class EIFModel(IntegrateFireModel):
         \text{if } V > V_{peak} \qquad \text{then} \qquad V \gets V_r.
     """
 
-    #: Non-dimensional parameters of the model.
     param: EIF
+    """Non-dimensional parameters of the model."""
 
     if __debug__:
 

--- a/src/pycaputo/integrate_fire/eif.py
+++ b/src/pycaputo/integrate_fire/eif.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: 2024 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import numpy as np
+
+from pycaputo.fode.base import advance
+from pycaputo.history import ProductIntegrationHistory
+from pycaputo.integrate_fire.base import (
+    AdvanceResult,
+    CaputoIntegrateFireL1Method,
+    IntegrateFireModel,
+)
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array, dc_stringify
+
+logger = get_logger(__name__)
+
+# {{{ model
+
+
+class EIFDim(NamedTuple):
+    """Dimensional parameters for the Exponential Integrate-and-Fire (EIF) model."""
+
+    #: Added current :math:`I` (in picoamperes *pA*).
+    current: float
+    #: Total capacitance :math:`C` (in picofarad per millisecond *pF / ms^(alpha - 1)*).
+    C: float
+    #: Total leak conductance :math:`g_L` (in nanosiemens *nS*).
+    gl: float
+    #: Equilibrium potential leak :math:`E_L` (in microvolts *mV*).
+    e_leak: float
+    #: Threshold slope factor :math:`\Delta_T` (in microvolts *mV*).
+    delta_t: float
+    #: Effective threshold potential :math:`V_T` (in microvolts *mV*).
+    vt: float
+
+    #: Peak potential :math:`V_{peak}` (in millivolts: *mV*).
+    v_peak: float
+    #: Reset potential :math:`V_r` (in millivolts: *mV*).
+    v_reset: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "I      (current / pA)": self.current,
+                "C      (total capacitance / pF/ms^alpha)": self.C,
+                "g_L    (total leak conductance / nS)": self.gl,
+                "E_leak (equilibrium potential leak / mV)": self.e_leak,
+                "delta_T(threshold slope factor / mV)": self.delta_t,
+                "V_T    (effective threshold potential / mV)": self.vt,
+                "V_peak (peak potential / mV)": self.v_peak,
+                "V_r    (reset potential / mV)": self.v_reset,
+            },
+            header=("model", type(self).__name__),
+        )
+
+    def nondim(self, alpha: float) -> EIF:
+        r"""Construct a non-dimensional set of parameters for the EIF model.
+
+        The non-dimensionalization is performed using the following rescaling
+
+        .. math::
+
+            \hat{t} = \sqrt[\alpha]{\frac{g_L}{C}} t,
+            \qquad
+            \hat{V} = \frac{V - V_T}{\Delta_T},
+            \qquad
+            \hat{I} = \frac{I}{g_L \Delta_T},
+
+        which results in a reduction of the parameter space to just the threshold
+        values :math:`(V_{peak}, V_r)` and the constants :math:`(I, E_L)`.
+
+        :arg alpha: the order of the fractional derivative.
+        """
+        return EIF(
+            alpha=alpha,
+            T=(self.gl / self.C) ** (1 / alpha),
+            current=self.current / (self.gl * self.delta_t),
+            e_leak=(self.e_leak - self.vt) / self.delta_t,
+            v_peak=(self.v_peak - self.vt) / self.delta_t,
+            v_reset=(self.v_reset - self.vt) / self.delta_t,
+        )
+
+
+class EIF(NamedTuple):
+    """Non-dimensional parameters for the EIF model (see :class:`EIFDim`)."""
+
+    #: Fractional order used in the non-dimensionalization.
+    alpha: float
+    #: Fractional time scale.
+    T: float
+
+    #: Current :math:`I`.
+    current: float
+    #: Equilibrium potential leak :math:`E_L`.
+    e_leak: float
+
+    #: Peak potential :math:`V_{peak}`.
+    v_peak: float
+    #: Reset potential :math:`V_r`.
+    v_reset: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "alpha  (fractional order)": self.alpha,
+                "T      (fractional time scale)": self.T,
+                "I      (current)": self.current,
+                "E_leak (equilibrium potential leak)": self.e_leak,
+                "V_peak (peak potential)": self.v_peak,
+                "V_r    (reset potential)": self.v_reset,
+            },
+            header=("model", type(self).__name__),
+        )
+
+
+@dataclass(frozen=True)
+class EIFModel(IntegrateFireModel):
+    r"""Functionals for the EIF model with parameters :class:`EIF`.
+
+    .. math::
+
+        D_C^\alpha[V](t) = I(t) - (V - E_L) + \exp V,
+
+    where :math:`I` is taken to be a constant by default, but can be
+    easily overwritten by subclasses. The reset condition is given by
+
+    .. math::
+
+        \text{if } V > V_{peak} \qquad \text{then} \qquad V \gets V_r.
+    """
+
+    #: Non-dimensional parameters of the model.
+    param: EIF
+
+    if __debug__:
+
+        def __post_init__(self) -> None:
+            if not isinstance(self.param, EIF):
+                raise TypeError(
+                    f"Invalid parameter type: '{type(self.param).__name__}'"
+                )
+
+    def source(self, t: float, y: Array) -> Array:
+        """Evaluate right-hand side of the LIF model."""
+        return np.array(self.param.current - (y - self.param.e_leak) + np.exp(y))
+
+    def source_jac(self, t: float, y: Array) -> Array:
+        """Evaluate the Jacobian of the right-hand side of the LIF model."""
+        return -1.0 + np.exp(y)
+
+    def spiked(self, t: float, y: Array) -> float:
+        """Compute a delta from the peak threshold :math:`V_{peak}`.
+
+        :returns: a delta of :math:`V - V_{peak}` that can be used to determine
+            if the neuron spiked.
+        """
+
+        (V,) = np.real_if_close(y)
+        return float(V - self.param.v_peak)
+
+    def reset(self, t: float, y: Array) -> Array:
+        """Evaluate the reset values for the LIF model.
+
+        This function assumes that the neuron has spiked, i.e. that :meth:`spiked`
+        returns a non-negative value. If this is not the case, the reset should
+        not be applied.
+        """
+        # TODO: should this be a proper check?
+        assert self.spiked(t, y) > -10.0 * np.finfo(y.dtype).eps
+
+        return np.full_like(y, self.param.v_reset)
+
+
+# }}}
+
+
+# {{{ CaputoExponentialIntegrateFireL1Method
+
+
+@dataclass(frozen=True)
+class CaputoExponentialIntegrateFireL1Method(CaputoIntegrateFireL1Method[EIFModel]):
+    r"""Implementation of the L1 method for the Exponential Integrate-and-Fire model.
+
+    The model is described by :class:`EIFModel` with parameters :class:`EIF`.
+    """
+
+    model: EIFModel
+
+    def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
+        r"""Solve the implicit equation for the EIF model.
+
+        In this case, since the right-hand side is nonlinear, but we can solve
+        the implicit equation using the Lambert W function, a special function
+        that is a solution to
+
+        .. math::
+
+            z = w e^w.
+        """
+        from scipy.special import lambertw
+
+        d0 = 1 + c
+        d1 = c
+        # NOTE: we need the terms that do not depend on V, so we do
+        #   f(t, y) + y - exp(y) = I(t) + E_L
+        # since the current may be time-dependent
+        d2 = r + c * (self.source(t, y0) + y0 - np.exp(y0))
+
+        V = d2 / d0 - lambertw(-d1 / d0 * np.exp(d2 / d0), tol=1.0e-12)
+        V = np.real_if_close(V, tol=100)
+
+        assert np.linalg.norm(V - c * self.source(t, V) - r) < 1.0e-8
+
+        return np.array(V)
+
+
+@advance.register(CaputoExponentialIntegrateFireL1Method)
+def _advance_caputo_eif_l1(
+    m: CaputoExponentialIntegrateFireL1Method,
+    history: ProductIntegrationHistory,
+    y: Array,
+    dt: float,
+) -> AdvanceResult:
+    from pycaputo.integrate_fire.base import (
+        advance_caputo_integrate_fire_l1,
+        advance_caputo_integrate_fire_spike_exp,
+    )
+
+    tprev = history.current_time
+    t = tprev + dt
+
+    result = advance_caputo_integrate_fire_l1(m, history, y, dt)
+
+    is_complex = np.any(np.iscomplex(result.y))
+    if is_complex or m.model.spiked(t, result.y) > 0.0:
+        p = m.model.param
+        result = advance_caputo_integrate_fire_spike_exp(
+            tprev, y, t, result, v_peak=p.v_peak, v_reset=p.v_reset
+        )
+
+        from pycaputo.controller import AdaptiveController
+
+        if is_complex and isinstance(m.control, AdaptiveController):
+            c = m.control
+
+            if dt < c.dtmin or c.nrejects > c.max_rejects:
+                # NOTE: we really tried to reduce the time step until the spike
+                # occurred, so now it's time to give up and spike!
+                pass
+            else:
+                result = result._replace(spiked=np.array(0))
+
+    return result
+
+
+# }}}

--- a/src/pycaputo/integrate_fire/eif.py
+++ b/src/pycaputo/integrate_fire/eif.py
@@ -277,6 +277,12 @@ class CaputoExponentialIntegrateFireL1Method(CaputoIntegrateFireL1Method[EIFMode
 
     model: EIFModel
 
+    @property
+    def order(self) -> float:
+        # NOTE: this is currently not tested, but it should match the PIF/LIF
+        # estimates for the time step even though it does not do the interpolation
+        return 1.0
+
     def solve(self, t: float, y: Array, h: Array, r: Array) -> Array:
         r"""Solve the implicit equation for the EIF model.
 

--- a/src/pycaputo/integrate_fire/eif.py
+++ b/src/pycaputo/integrate_fire/eif.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
-    CaputoIntegrateFireL1Method,
+    IntegrateFireMethod,
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
@@ -269,7 +269,7 @@ def find_maximum_time_step_lambert(
 
 
 @dataclass(frozen=True)
-class CaputoExponentialIntegrateFireL1Method(CaputoIntegrateFireL1Method[EIFModel]):
+class CaputoExponentialIntegrateFireL1Method(IntegrateFireMethod[EIFModel]):
     r"""Implementation of the L1 method for the Exponential Integrate-and-Fire model.
 
     The model is described by :class:`EIFModel` with parameters :class:`EIF`.

--- a/src/pycaputo/integrate_fire/eif.py
+++ b/src/pycaputo/integrate_fire/eif.py
@@ -311,10 +311,8 @@ def _advance_caputo_eif_l1(  # type: ignore[misc]
     dt: float,
 ) -> AdvanceResult:
     from pycaputo.controller import AdaptiveController
-    from pycaputo.integrate_fire.base import (
-        advance_caputo_integrate_fire_l1,
-        estimate_spike_time_exp,
-    )
+    from pycaputo.integrate_fire.base import advance_caputo_integrate_fire_l1
+    from pycaputo.integrate_fire.spikes import estimate_spike_time_exp
 
     c = m.control
     assert isinstance(c, AdaptiveController)

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -8,7 +8,6 @@ from typing import NamedTuple, overload
 
 import numpy as np
 
-from pycaputo.fode.base import advance
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
@@ -16,6 +15,7 @@ from pycaputo.integrate_fire.base import (
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
+from pycaputo.stepping import advance
 from pycaputo.utils import Array, dc_stringify
 
 logger = get_logger(__name__)

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -263,7 +263,7 @@ def _advance_caputo_lif_l1(
     tprev = history.current_time
     t = tprev + dt
 
-    result = advance_caputo_integrate_fire_l1(m, history, y, dt)
+    result, _ = advance_caputo_integrate_fire_l1(m, history, y, dt)
     if m.model.spiked(t, result.y) > 0.0:
         p = m.model.param
         result = advance_caputo_integrate_fire_spike_linear(

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
-    CaputoIntegrateFireL1Method,
+    IntegrateFireMethod,
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
@@ -253,7 +253,7 @@ class LIFModel(IntegrateFireModel):
 
 
 @dataclass(frozen=True)
-class CaputoLeakyIntegrateFireL1Method(CaputoIntegrateFireL1Method[LIFModel]):
+class CaputoLeakyIntegrateFireL1Method(IntegrateFireMethod[LIFModel]):
     r"""Implementation of the L1 method for the Leaky Integrate-and-Fire model.
 
     The model is described by :class:`LIFModel` with parameters :class:`LIF`.

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2024 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import numpy as np
+
+from pycaputo.fode.base import advance
+from pycaputo.history import ProductIntegrationHistory
+from pycaputo.integrate_fire.base import (
+    AdvanceResult,
+    CaputoIntegrateFireL1Method,
+    IntegrateFireModel,
+)
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array, dc_stringify
+
+logger = get_logger(__name__)
+
+
+# {{{ model
+
+
+class LIFDim(NamedTuple):
+    """Dimensional parameters for the Leaky Integrate-and-Fire (LIF) model."""
+
+    #: Added current :math:`I` (in picoamperes *pA*).
+    current: float
+    #: Total capacitance :math:`C` (in picofarad per millisecond *pF / ms^(alpha - 1)*).
+    C: float
+    #: Total leak conductance :math:`g_L` (in nanosiemens *nS*).
+    gl: float
+    #: Equilibrium potential leak :math:`E_L` (in microvolts *mV*).
+    e_leak: float
+
+    #: Peak potential :math:`V_{peak}` (in millivolts: *mV*).
+    v_peak: float
+    #: Reset potential :math:`V_r` (in millivolts: *mV*).
+    v_reset: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "I      (current / pA)": self.current,
+                "C      (total capacitance / pF/ms^alpha)": self.C,
+                "g_L    (total leak conductance / nS)": self.gl,
+                "E_leak (equilibrium potential leak / mV)": self.e_leak,
+                "V_peak (peak potential / mV)": self.v_peak,
+                "V_r    (reset potential / mV)": self.v_reset,
+            },
+            header=("model", type(self).__name__),
+        )
+
+    def nondim(self, alpha: float, *, v_ref: float | None = None) -> LIF:
+        r"""Construct a non-dimensional set of parameters for the LIF model.
+
+        The non-dimensionalization is performed using the following rescaling
+
+        .. math::
+
+            \hat{t} = \sqrt[\alpha]{\frac{g_L}{C}} t,
+            \qquad
+            \hat{V} = \frac{V}{V_{ref}},
+            \qquad
+            \hat{I} = \frac{I}{g_L V_{ref}},
+
+        which results in a reduction of the parameter space to just the threshold
+        values :math:`(V_{peak}, V_r)` and the constants :math:`(I, E_L)`.
+
+        :arg alpha: the order of the fractional derivative.
+        :arg v_ref: a reference potential used in non-dimensionalizing the
+            membrane potential.
+        """
+        if v_ref is None:
+            v_ref = max(abs(self.v_peak), abs(self.v_reset))
+        v_ref = abs(v_ref)
+
+        return LIF(
+            alpha=alpha,
+            T=(self.gl / self.C) ** (1 / alpha),
+            current=self.current / (self.gl * v_ref),
+            e_leak=self.e_leak / v_ref,
+            v_peak=self.v_peak / v_ref,
+            v_reset=self.v_reset / v_ref,
+        )
+
+
+class LIF(NamedTuple):
+    """Non-dimensional parameters for the LIF model (see :class:`LIFDim`)."""
+
+    #: Fractional order used in the non-dimensionalization.
+    alpha: float
+    #: Fractional time scale.
+    T: float
+
+    #: Current :math:`I`.
+    current: float
+    #: Equilibrium potential leak :math:`E_L`.
+    e_leak: float
+
+    #: Peak potential :math:`V_{peak}`.
+    v_peak: float
+    #: Reset potential :math:`V_r`.
+    v_reset: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "alpha  (fractional order)": self.alpha,
+                "T      (fractional time scale)": self.T,
+                "I      (current)": self.current,
+                "E_leak (equilibrium potential leak)": self.e_leak,
+                "V_peak (peak potential)": self.v_peak,
+                "V_r    (reset potential)": self.v_reset,
+            },
+            header=("model", type(self).__name__),
+        )
+
+
+@dataclass(frozen=True)
+class LIFModel(IntegrateFireModel):
+    r"""Functionals for the LIF model with parameters :class:`LIF`.
+
+    .. math::
+
+        D_C^\alpha[V](t) = I(t) - (V - E_L),
+
+    where :math:`I` is taken to be a constant by default, but can be
+    easily overwritten by subclasses. The reset condition is also given by
+
+    .. math::
+
+        \text{if } V > V_{peak} \qquad \text{then} \qquad V \gets V_r.
+    """
+
+    #: Non-dimensional parameters of the model.
+    param: LIF
+
+    if __debug__:
+
+        def __post_init__(self) -> None:
+            if not isinstance(self.param, LIF):
+                raise TypeError(
+                    f"Invalid parameter type: '{type(self.param).__name__}'"
+                )
+
+    def source(self, t: float, y: Array) -> Array:
+        """Evaluate right-hand side of the LIF model."""
+        return self.param.current - (y - self.param.e_leak)
+
+    def source_jac(self, t: float, y: Array) -> Array:
+        """Evaluate the Jacobian of the right-hand side of the LIF model."""
+        return np.full_like(y, -1.0)
+
+    def spiked(self, t: float, y: Array) -> float:
+        """Compute a delta from the peak threshold :math:`V_{peak}`.
+
+        :returns: a delta of :math:`V - V_{peak}` that can be used to determine
+            if the neuron spiked.
+        """
+
+        (V,) = y
+        return float(V - self.param.v_peak)
+
+    def reset(self, t: float, y: Array) -> Array:
+        """Evaluate the reset values for the LIF model.
+
+        This function assumes that the neuron has spiked, i.e. that :meth:`spiked`
+        returns a non-negative value. If this is not the case, the reset should
+        not be applied.
+        """
+        # TODO: should this be a proper check?
+        assert self.spiked(t, y) > -10.0 * np.finfo(y.dtype).eps
+
+        return np.full_like(y, self.param.v_reset)
+
+
+# }}}
+
+
+# {{{ CaputoLeakyIntegrateFireL1Method
+
+
+@dataclass(frozen=True)
+class CaputoLeakyIntegrateFireL1Method(CaputoIntegrateFireL1Method[LIFModel]):
+    r"""Implementation of the L1 method for the Leaky Integrate-and-Fire model.
+
+    The model is described by :class:`LIFModel` with parameters :class:`LIF`.
+    """
+
+    model: LIFModel
+
+    def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
+        r"""Solve the implicit equation for the LIF model.
+
+        In this case, since the right-hand side is linear, so we can solve the
+        implicit equation exactly as
+
+        .. math::
+
+            y_{n + 1} = \frac{c I(t_{n + 1}) + c E_L + r}{1 + c}
+        """
+        # NOTE: we need the terms that do not depend on V, so we do
+        #   f(t, y) + y - exp(y) = I(t) + E_L
+        # since the current may be time-dependent
+        current = self.source(t, y0) + y0
+
+        result = (c * current + r) / (1 + c)
+        return np.array(result)
+
+
+@advance.register(CaputoLeakyIntegrateFireL1Method)
+def _advance_caputo_lif_l1(
+    m: CaputoLeakyIntegrateFireL1Method,
+    history: ProductIntegrationHistory,
+    y: Array,
+    dt: float,
+) -> AdvanceResult:
+    from pycaputo.integrate_fire.base import (
+        advance_caputo_integrate_fire_l1,
+        advance_caputo_integrate_fire_spike_linear,
+    )
+
+    tprev = history.current_time
+    t = tprev + dt
+
+    result = advance_caputo_integrate_fire_l1(m, history, y, dt)
+    if m.model.spiked(t, result.y) > 0.0:
+        p = m.model.param
+        result = advance_caputo_integrate_fire_spike_linear(
+            tprev, y, t, result, v_peak=p.v_peak, v_reset=p.v_reset
+        )
+
+    return result
+
+
+# }}}

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -71,15 +71,15 @@ def _find_first_spike_time(p: LIF, V0: float = 0.0) -> float:
 class LIFReference(NamedTuple):
     """Reference variables used to non-dimensionalize the LIF model."""
 
-    #: Fractional order used to non-dimensionalize.
     alpha: float
+    """Fractional order used to non-dimensionalize."""
 
-    #: Time scale (in milliseconds: *ms*).
     T_ref: float
-    #: Voltage scale (in millivolts: *mV*).
+    """Time scale (in milliseconds: *ms*)."""
     V_ref: float
-    #: Current scale (in picoamperes: *pA*).
+    """Voltage scale (in millivolts: *mV*)."""
     I_ref: float
+    """Current scale (in picoamperes: *pA*)."""
 
     @overload
     def time(self, t: float) -> float: ...
@@ -99,19 +99,19 @@ class LIFReference(NamedTuple):
 class LIFDim(NamedTuple):
     """Dimensional parameters for the Leaky Integrate-and-Fire (LIF) model."""
 
-    #: Added current :math:`I` (in picoamperes *pA*).
     current: float
-    #: Total capacitance :math:`C` (in picofarad per millisecond *pF / ms^(alpha - 1)*).
+    """Added current :math:`I` (in picoamperes *pA*)."""
     C: float
-    #: Total leak conductance :math:`g_L` (in nanosiemens *nS*).
+    """Total capacitance :math:`C` (in picofarad per ms *pF / ms^(alpha - 1)*)."""
     gl: float
-    #: Equilibrium potential leak :math:`E_L` (in microvolts *mV*).
+    """Total leak conductance :math:`g_L` (in nanosiemens *nS*)."""
     e_leak: float
+    """Equilibrium potential leak :math:`E_L` (in microvolts *mV*)."""
 
-    #: Peak potential :math:`V_{peak}` (in millivolts: *mV*).
     v_peak: float
-    #: Reset potential :math:`V_r` (in millivolts: *mV*).
+    """Peak potential :math:`V_{peak}` (in millivolts: *mV*)."""
     v_reset: float
+    """Reset potential :math:`V_r` (in millivolts: *mV*)."""
 
     def __str__(self) -> str:
         return dc_stringify(
@@ -175,18 +175,18 @@ class LIFDim(NamedTuple):
 class LIF(NamedTuple):
     """Non-dimensional parameters for the LIF model (see :class:`LIFDim`)."""
 
-    #: Reference values used in non-dimensionalization.
     ref: LIFReference
+    """Reference values used in non-dimensionalization."""
 
-    #: Current :math:`I`.
     current: float
-    #: Equilibrium potential leak :math:`E_L`.
+    """Current :math:`I`."""
     e_leak: float
+    """Equilibrium potential leak :math:`E_L`."""
 
-    #: Peak potential :math:`V_{peak}`.
     v_peak: float
-    #: Reset potential :math:`V_r`.
+    """Peak potential :math:`V_{peak}`."""
     v_reset: float
+    """Reset potential :math:`V_r`."""
 
     def constant_spike_times(self, tfinal: float, V0: float = 0.0) -> Array:
         """Compute the spike times for a constant current.
@@ -228,8 +228,8 @@ class LIFModel(IntegrateFireModel):
         \text{if } V > V_{peak} \qquad \text{then} \qquad V \gets V_r.
     """
 
-    #: Non-dimensional parameters of the model.
     param: LIF
+    """Non-dimensional parameters of the model."""
 
     if __debug__:
 

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -259,8 +259,6 @@ class CaputoLeakyIntegrateFireL1Method(IntegrateFireMethod[LIFModel]):
     The model is described by :class:`LIFModel` with parameters :class:`LIF`.
     """
 
-    model: LIFModel
-
     def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
         r"""Solve the implicit equation for the LIF model.
 
@@ -281,7 +279,7 @@ class CaputoLeakyIntegrateFireL1Method(IntegrateFireMethod[LIFModel]):
 
 
 @advance.register(CaputoLeakyIntegrateFireL1Method)
-def _advance_caputo_lif_l1(
+def _advance_caputo_lif_l1(  # type: ignore[misc]
     m: CaputoLeakyIntegrateFireL1Method,
     history: ProductIntegrationHistory,
     y: Array,
@@ -292,12 +290,13 @@ def _advance_caputo_lif_l1(
         advance_caputo_integrate_fire_spike_linear,
     )
 
+    model = m.source
     tprev = history.current_time
     t = tprev + dt
 
     result, _ = advance_caputo_integrate_fire_l1(m, history, y, dt)
-    if m.model.spiked(t, result.y) > 0.0:
-        p = m.model.param
+    if model.spiked(t, result.y) > 0.0:
+        p = model.param
         result = advance_caputo_integrate_fire_spike_linear(
             tprev, y, t, result, v_peak=p.v_peak, v_reset=p.v_reset
         )

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -322,7 +322,7 @@ def _advance_caputo_lif_l1(  # type: ignore[misc]
     if model.spiked(t, result.y) > 0.0:
         p = model.param
         result = advance_caputo_integrate_fire_spike_linear(
-            tprev, y, t, result, v_peak=p.v_peak, v_reset=p.v_reset
+            t, result.y[0], history, v_peak=p.v_peak, v_reset=p.v_reset
         )
 
     return result

--- a/src/pycaputo/integrate_fire/lif.py
+++ b/src/pycaputo/integrate_fire/lif.py
@@ -47,9 +47,9 @@ class LIFReference(NamedTuple):
         """Add dimensions to the non-dimensional time *t*."""
         return self.T_ref * t
 
-    def potential(self, V: Array) -> Array:
-        """Add dimensions to the non-dimensional potential *V*."""
-        return self.V_ref * V
+    def var(self, y: Array) -> Array:
+        """Add dimensions to the non-dimensional potential *y*."""
+        return self.V_ref * y
 
 
 class LIFDim(NamedTuple):

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -8,7 +8,6 @@ from typing import NamedTuple, overload
 
 import numpy as np
 
-from pycaputo.fode.base import advance
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
@@ -16,6 +15,7 @@ from pycaputo.integrate_fire.base import (
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
+from pycaputo.stepping import advance
 from pycaputo.utils import Array, dc_stringify
 
 logger = get_logger(__name__)

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -275,7 +275,7 @@ def _advance_caputo_pif_l1(
     tprev = history.current_time
     t = tprev + dt
 
-    result = advance_caputo_integrate_fire_l1(m, history, y, dt)
+    result, _ = advance_caputo_integrate_fire_l1(m, history, y, dt)
     if m.model.spiked(t, result.y) > 0.0:
         p = m.model.param
         result = advance_caputo_integrate_fire_spike_linear(

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -258,8 +258,6 @@ class CaputoPerfectIntegrateFireL1Method(IntegrateFireMethod[PIFModel]):
     The model is described by :class:`PIFModel` with parameters :class:`PIF`.
     """
 
-    model: PIFModel
-
     def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
         r"""Solve the implicit equation for the PIF model.
 
@@ -274,7 +272,7 @@ class CaputoPerfectIntegrateFireL1Method(IntegrateFireMethod[PIFModel]):
 
 
 @advance.register(CaputoPerfectIntegrateFireL1Method)
-def _advance_caputo_pif_l1(
+def _advance_caputo_pif_l1(  # type: ignore[misc]
     m: CaputoPerfectIntegrateFireL1Method,
     history: ProductIntegrationHistory,
     y: Array,
@@ -285,12 +283,13 @@ def _advance_caputo_pif_l1(
         advance_caputo_integrate_fire_spike_linear,
     )
 
+    model = m.source
     tprev = history.current_time
     t = tprev + dt
 
     result, _ = advance_caputo_integrate_fire_l1(m, history, y, dt)
-    if m.model.spiked(t, result.y) > 0.0:
-        p = m.model.param
+    if model.spiked(t, result.y) > 0.0:
+        p = model.param
         result = advance_caputo_integrate_fire_spike_linear(
             tprev, y, t, result, v_peak=p.v_peak, v_reset=p.v_reset
         )

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -47,9 +47,9 @@ class PIFReference(NamedTuple):
         """Add dimensions to the non-dimensional time *t*."""
         return self.T_ref * t
 
-    def potential(self, V: Array) -> Array:
-        """Add dimensions to the non-dimensional potential *V*."""
-        return self.V_ref * V
+    def var(self, y: Array) -> Array:
+        """Add dimensions to the non-dimensional potential *y*."""
+        return self.V_ref * y
 
 
 class PIFDim(NamedTuple):

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: 2024 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import numpy as np
+
+from pycaputo.fode.base import advance
+from pycaputo.history import ProductIntegrationHistory
+from pycaputo.integrate_fire.base import (
+    AdvanceResult,
+    CaputoIntegrateFireL1Method,
+    IntegrateFireModel,
+)
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array, dc_stringify
+
+logger = get_logger(__name__)
+
+
+# {{{ model
+
+
+class PIFDim(NamedTuple):
+    """Dimensional parameters for the Perfect Integrate-and-Fire (PIF) model."""
+
+    #: Added current :math:`I` (in picoamperes: *pA*).
+    current: float
+    #: Total capacitance :math:`C` (in picofarad per millisecond:
+    #: *pF / ms^(alpha - 1)*).
+    C: float
+
+    #: Peak potential :math:`V_{peak}` (in millivolts: *mV*).
+    v_peak: float
+    #: Reset potential :math:`V_r` (in millivolts: *mV*).
+    v_reset: float
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "I      (current / pA)": self.current,
+                "C      (total capacitance / pF/ms^alpha)": self.C,
+                "V_peak (peak potential / mV)": self.v_peak,
+                "V_r    (reset potential / mV)": self.v_reset,
+            },
+            header=("model", type(self).__name__),
+        )
+
+    def nondim(
+        self,
+        alpha: float,
+        *,
+        v_ref: float | None = None,
+        I_ref: float | None = None,
+    ) -> PIF:
+        r"""Construct a non-dimensional set of parameters for the PIF model.
+
+        The non-dimensionalization is performed using the following rescaling
+
+        .. math::
+
+            \hat{t} = \sqrt[\alpha]{\frac{I_{ref}}{C V_{ref}}} t,
+            \qquad
+            \hat{V} = \frac{V}{V_{ref}},
+            \qquad
+            \hat{I} = \frac{I}{I_{ref}},
+
+        which results in a parameter space consisting of the threshold
+        values :math:`(\hat{V}_{peak}, \hat{V}_r)` and the non-dimenional
+        current :math:`\hat{I}`.
+
+        :arg alpha: the order of the fractional derivative.
+        :arg v_ref: a reference potential used in non-dimensionalizing the
+            membrane potential.
+        :arg I_ref: a reference current used in non-dimensionalizing the current.
+        """
+
+        if v_ref is None:
+            v_ref = max(abs(self.v_peak), abs(self.v_reset))
+        v_ref = abs(v_ref)
+
+        if I_ref is None:
+            I_ref = abs(self.current)
+        I_ref = abs(I_ref)
+
+        return PIF(
+            alpha=alpha,
+            T=(I_ref / (self.C * v_ref)) ** (1 / alpha),
+            current=self.current / I_ref,
+            v_peak=self.v_peak / v_ref,
+            v_reset=self.v_reset / v_ref,
+        )
+
+
+class PIF(NamedTuple):
+    """Non-dimensional parameters for the PIF model (see :class:`PIFDim`)."""
+
+    #: Fractional order used in the non-dimensionalization.
+    alpha: float
+    #: Fractional time scale.
+    T: float
+
+    #: Current.
+    current: float
+    #: Peak potential :math:`V_{peak}`.
+    v_peak: float
+    #: Reset potential :math:`V_r`.
+    v_reset: float
+
+    def first_spike_time(self, V0: float = 0.0) -> float:
+        """Compute the first spike time for a constant current.
+
+        :arg V0: initial membrane current.
+        """
+        from math import gamma
+
+        ts = gamma(1 + self.alpha) * (self.v_peak - V0) / self.current
+        return float(ts ** (1 / self.alpha))
+
+    def __str__(self) -> str:
+        return dc_stringify(
+            {
+                "alpha  (fractional order)": self.alpha,
+                "T      (fractional time scale)": self.T,
+                "I      (current)": self.current,
+                "V_peak (peak potential)": self.v_peak,
+                "V_r    (reset potential)": self.v_reset,
+            },
+            header=("model", type(self).__name__),
+        )
+
+
+@dataclass(frozen=True)
+class PIFModel(IntegrateFireModel):
+    r"""Functionals for the PIF model with parameters :class:`PIF`.
+
+    .. math::
+
+        D_C^\alpha[V](t) = I(t),
+
+    where :math:`I` is taken to be a constant by default, but can be
+    easily overwritten by subclasses. The reset condition is also given by
+
+    .. math::
+
+        \text{if } V > V_{peak} \qquad \text{then} \qquad V \gets V_r.
+    """
+
+    #: Non-dimensional parameters of the model.
+    param: PIF
+
+    if __debug__:
+
+        def __post_init__(self) -> None:
+            if not isinstance(self.param, PIF):
+                raise TypeError(
+                    f"Invalid parameter type: '{type(self.param).__name__}'"
+                )
+
+    def source(self, t: float, y: Array) -> Array:
+        """Evaluate right-hand side of the PIF model."""
+        return np.full_like(y, self.param.current)
+
+    def source_jac(self, t: float, y: Array) -> Array:
+        """Evaluate the Jacobian of the right-hand side of the PIF model."""
+        return np.zeros_like(y)
+
+    def spiked(self, t: float, y: Array) -> float:
+        """Compute a delta from the peak threshold :math:`V_{peak}`.
+
+        :returns: a delta of :math:`V - V_{peak}` that can be used to determine
+            if the neuron spiked.
+        """
+
+        (V,) = y
+        return float(V - self.param.v_peak)
+
+    def reset(self, t: float, y: Array) -> Array:
+        """Evaluate the reset values for the PIF model.
+
+        This function assumes that the neuron has spiked, i.e. that :meth:`spiked`
+        returns a non-negative value. If this is not the case, the reset should
+        not be applied.
+        """
+        # TODO: should this be a proper check?
+        assert self.spiked(t, y) > -10.0 * np.finfo(y.dtype).eps
+
+        return np.full_like(y, self.param.v_reset)
+
+
+# }}}
+
+
+# {{{ CaputoPerfectIntegrateFireL1Method
+
+
+@dataclass(frozen=True)
+class CaputoPerfectIntegrateFireL1Method(CaputoIntegrateFireL1Method[PIFModel]):
+    r"""Implementation of the L1 method for the Perfect Integrate-and-Fire model.
+
+    The model is described by :class:`PIFModel` with parameters :class:`PIF`.
+    """
+
+    model: PIFModel
+
+    def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
+        r"""Solve the implicit equation for the PIF model.
+
+        In this case, since the right-hand side does not depend on the solution,
+        we simply have that
+
+        .. math::
+
+            y_{n + 1} = c f(t_{n + 1}, \cdot) + r
+        """
+        return c * self.source(t, y0) + r
+
+
+@advance.register(CaputoPerfectIntegrateFireL1Method)
+def _advance_caputo_pif_l1(
+    m: CaputoPerfectIntegrateFireL1Method,
+    history: ProductIntegrationHistory,
+    y: Array,
+    dt: float,
+) -> AdvanceResult:
+    from pycaputo.integrate_fire.base import (
+        advance_caputo_integrate_fire_l1,
+        advance_caputo_integrate_fire_spike_linear,
+    )
+
+    tprev = history.current_time
+    t = tprev + dt
+
+    result = advance_caputo_integrate_fire_l1(m, history, y, dt)
+    if m.model.spiked(t, result.y) > 0.0:
+        p = m.model.param
+        result = advance_caputo_integrate_fire_spike_linear(
+            tprev, y, t, result, v_peak=p.v_peak, v_reset=p.v_reset
+        )
+
+    return result
+
+
+# }}}

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -27,15 +27,15 @@ logger = get_logger(__name__)
 class PIFReference(NamedTuple):
     """Reference variables used to non-dimensionalize the PIF model."""
 
-    #: Fractional order used to non-dimensionalize.
     alpha: float
+    """Fractional order used to non-dimensionalize."""
 
-    #: Time scale (in milliseconds: *ms*).
     T_ref: float
-    #: Voltage scale (in millivolts: *mV*).
+    """Time scale (in milliseconds: *ms*)."""
     V_ref: float
-    #: Current scale (in picoamperes: *pA*).
+    """Voltage scale (in millivolts: *mV*)."""
     I_ref: float
+    """Current scale (in picoamperes: *pA*)."""
 
     @overload
     def time(self, t: float) -> float: ...
@@ -55,16 +55,15 @@ class PIFReference(NamedTuple):
 class PIFDim(NamedTuple):
     """Dimensional parameters for the Perfect Integrate-and-Fire (PIF) model."""
 
-    #: Added current :math:`I` (in picoamperes: *pA*).
     current: float
-    #: Total capacitance :math:`C` (in picofarad per millisecond:
-    #: *pF / ms^(alpha - 1)*).
+    """Added current :math:`I` (in picoamperes: *pA*)."""
     C: float
+    """Total capacitance :math:`C` (in picofarad per ms: *pF / ms^(alpha - 1)*)."""
 
-    #: Peak potential :math:`V_{peak}` (in millivolts: *mV*).
     v_peak: float
-    #: Reset potential :math:`V_r` (in millivolts: *mV*).
+    """Peak potential :math:`V_{peak}` (in millivolts: *mV*)."""
     v_reset: float
+    """Reset potential :math:`V_r` (in millivolts: *mV*)."""
 
     def __str__(self) -> str:
         return dc_stringify(
@@ -143,15 +142,15 @@ class PIFDim(NamedTuple):
 class PIF(NamedTuple):
     """Non-dimensional parameters for the PIF model (see :class:`PIFDim`)."""
 
-    #: Reference values used in non-dimensionalization.
     ref: PIFReference
+    """Reference values used in non-dimensionalization."""
 
-    #: Current.
     current: float
-    #: Peak potential :math:`V_{peak}`.
+    """Current."""
     v_peak: float
-    #: Reset potential :math:`V_r`.
+    """Peak potential :math:`V_{peak}`."""
     v_reset: float
+    """Reset potential :math:`V_r`."""
 
     def constant_spike_times(self, tfinal: float, V0: float = 0.0) -> Array:
         """Compute the spike times for a constant current.
@@ -203,8 +202,8 @@ class PIFModel(IntegrateFireModel):
         \text{if } V > V_{peak} \qquad \text{then} \qquad V \gets V_r.
     """
 
-    #: Non-dimensional parameters of the model.
     param: PIF
+    """Non-dimensional parameters of the model."""
 
     if __debug__:
 

--- a/src/pycaputo/integrate_fire/pif.py
+++ b/src/pycaputo/integrate_fire/pif.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.integrate_fire.base import (
     AdvanceResult,
-    CaputoIntegrateFireL1Method,
+    IntegrateFireMethod,
     IntegrateFireModel,
 )
 from pycaputo.logging import get_logger
@@ -252,7 +252,7 @@ class PIFModel(IntegrateFireModel):
 
 
 @dataclass(frozen=True)
-class CaputoPerfectIntegrateFireL1Method(CaputoIntegrateFireL1Method[PIFModel]):
+class CaputoPerfectIntegrateFireL1Method(IntegrateFireMethod[PIFModel]):
     r"""Implementation of the L1 method for the Perfect Integrate-and-Fire model.
 
     The model is described by :class:`PIFModel` with parameters :class:`PIF`.

--- a/src/pycaputo/integrate_fire/spikes.py
+++ b/src/pycaputo/integrate_fire/spikes.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2024 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import numpy as np
+
+from pycaputo.utils import Array
+
+# {{{ linear spike time estimate
+
+
+def estimate_spike_time_linear(
+    t: float, V: Array, tprev: float, Vprev: Array, Vpeak: Array | float
+) -> float:
+    """Give a linear estimation of the spike time.
+
+    .. math::
+
+        V(t) = a t + b.
+
+    We assume that the spike occurred between :math:`(t, V)` and
+    :math:`(t_{prev}, V_{prev})` at :math:`V_{peak}`. This information can be
+    used to provide a simple linear estimation for the spike time.
+
+    :return: an estimation of the spike time.
+    """
+    assert Vprev <= Vpeak <= V
+    ts = (Vpeak - Vprev) / (V - Vprev) * t + (V - Vpeak) / (V - Vprev) * tprev
+    assert tprev <= ts <= t
+
+    return float(ts)
+
+
+# }}}
+
+
+# {{{ quadratic spike time estimate
+
+
+def estimate_spike_time_quadratic(
+    t: float,
+    V: Array,
+    tprev: float,
+    Vprev: Array,
+    tpprev: float,
+    Vpprev: Array,
+    Vpeak: Array | float,
+) -> float:
+    """Give a quadratic estimation of the spike time.
+
+    .. math::
+
+        V(t) = a t^2 + b t + c.
+
+    We assume that the spike occurred between :math:`(t, V)` and
+    :math:`(t_{prev}, V_{prev})` at :math:`V_{peak}`. This information can be
+    used to provide a simple quadratic estimation for the spike time.
+
+    :return: an estimation of the spike time.
+    """
+    assert Vpprev <= Vprev <= Vpeak <= V
+    assert tpprev < tprev < t
+
+    a = ((V - Vprev) / (t - tprev) - (Vprev - Vpprev) / (tprev - tpprev)) / (t - tpprev)
+    b = (
+        tpprev**2 * (V - Vprev) - tprev**2 * (V - Vpprev) + t**2 * (Vprev - Vpprev)
+    ) / ((tprev - tpprev) * (t - tpprev) * (t - tprev))
+    c = Vpprev - (Vprev - Vpprev) / (tprev - tpprev) * tpprev + tpprev * tprev * a
+    d = b**2 - 4 * a * (c - Vpeak)
+    assert d >= 0
+
+    ts = (-b + np.sqrt(d)) / (2 * a)
+
+    assert tprev < ts < t
+    return float(ts)
+
+
+# }}}
+
+
+# {{{ exponential spike time estimate
+
+
+def estimate_spike_time_exp(
+    t: float, V: Array, tprev: float, Vprev: Array, Vpeak: Array | float
+) -> float:
+    """Give an exponential estimation of the spike time.
+
+    .. math::
+
+        V(t) = a e^t + b.
+
+    :returns: an estimate of the spike time.
+    """
+    assert Vprev <= Vpeak <= V
+    assert tprev < t
+
+    ts = np.log(
+        (Vpeak - Vprev) / (V - Vprev) * np.exp(t)
+        + (V - Vpeak) / (V - Vprev) * np.exp(tprev)
+    )
+
+    assert tprev <= ts <= t
+    return float(ts)
+
+
+# }}}

--- a/src/pycaputo/mittagleffler.py
+++ b/src/pycaputo/mittagleffler.py
@@ -52,6 +52,12 @@ def mittag_leffler_series(
     if kmax is None:
         kmax = 2048
 
+    if abs(z) >= 1.0:
+        raise ValueError(
+            "The series expansion of the Mittag-Leffler function "
+            "only converges for |z| < 1"
+        )
+
     result, term = 0j, 1j
     k = 0
     while abs(term) > eps and k <= kmax:
@@ -244,7 +250,7 @@ def mittag_leffler_diethelm(
         return K + P
 
     k0 = math.floor(-math.log(eps) / math.log(zabs))
-    result = -sum((z**-k / math.gamma(beta - alpha * k) for k in range(k0)), 0.0)
+    result = -sum((z**-k / math.gamma(beta - alpha * k + eps) for k in range(k0)), 0.0)
 
     if zarg < 0.75 * alpha * np.pi:
         result += z ** ((1 - beta) / alpha) * cmath.exp(z ** (1 / alpha)) / alpha

--- a/src/pycaputo/utils.py
+++ b/src/pycaputo/utils.py
@@ -79,7 +79,6 @@ class ScalarFunction(Protocol):
         """
 
 
-@runtime_checkable
 class StateFunction(Protocol):
     r"""A generic callable for right-hand side functions
     :math:`\mathbf{f}(t, \mathbf{y})`.

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import pathlib
+from functools import partial
+
+import numpy as np
+import pytest
+
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array, set_recommended_matplotlib
+
+logger = get_logger("pycaputo.test_integrate_fire")
+dirname = pathlib.Path(__file__).parent
+set_recommended_matplotlib()
+
+# {{{ test_ad_ex_parameters
+
+
+def test_ad_ex_parameters() -> None:
+    from pycaputo.integrate_fire.ad_ex import AD_EX_PARAMS
+
+    alpha = (0.77, 0.31)
+    for name, param in AD_EX_PARAMS.items():
+        ad_ex = param.nondim(alpha)
+        assert all(np.all(np.isfinite(np.array(v))) for v in ad_ex)
+        assert str(param)
+        assert str(ad_ex)
+
+        logger.info("[%s] Parameters:\n%s\n%s", name, param, ad_ex)
+
+        assert ad_ex.T > 0
+        assert ad_ex.tau_w > 0
+        assert ad_ex.v_peak > ad_ex.v_reset
+
+
+# }}}
+
+
+# {{{ test_ad_ex_lambert_arg
+
+
+def ad_ex_lambert_zero_roots(
+    a: float, tau_w: float, alpha: float
+) -> tuple[float, float]:
+    r"""Computes the zeros of :func:`ad_ex_zero` below.
+
+    This is only valid if :math:`h \in [0, 1]`. In other case, we will get
+    negative values that do not make any sense.
+    """
+    from math import sqrt
+
+    a = 1 + a
+    b = 1 + tau_w
+    c = tau_w
+
+    if a == 0:
+        return -c / b, -c / b
+
+    h_min = -b / (2 * a)
+    delta = b**2 - 4 * a * c
+    if delta <= 0:
+        return np.nan, np.nan
+
+    delta = sqrt(delta) / (2 * a)
+    return h_min - delta, h_min + delta
+
+
+def ad_ex_zero(a: float, tau_w: float, h: Array) -> Array:
+    return (1 + (1 + a * h / (h + tau_w)) * h) / h
+
+
+def test_ad_ex_lambert_arg(*, visualize: bool = True) -> None:
+    from math import gamma
+
+    from pycaputo.integrate_fire.ad_ex import AD_EX_PARAMS
+
+    dirname = pathlib.Path(__file__).parent
+    alpha = 0.9
+    a, b = 0, gamma(2 - alpha)
+
+    for name, param in AD_EX_PARAMS.items():
+        ad_ex = param.nondim(alpha)
+        logger.info("[%s] Parameters: a %.12e tau_w %.12e", name, ad_ex.a, ad_ex.tau_w)
+
+        hm, hp = ad_ex_lambert_zero_roots(ad_ex.a, ad_ex.tau_w, alpha)
+        hmin = (hp + hm) / 2.0
+        logger.info("[%s] hp %.12e hm %.12e hmin %.12e", name, hp, hm, hmin)
+        logger.info("[%s] Works? %s", name, a < hm < b or a < hp < b)
+
+        func = partial(ad_ex_zero, ad_ex.a, ad_ex.tau_w)
+        assert np.isnan(hm) or abs(func(hm)) <= 5.0e-14, func(hm)
+        assert np.isnan(hp) or abs(func(hp)) <= 5.0e-14, func(hp)
+
+        if visualize:
+            from pycaputo.utils import figure
+
+            if np.isnan(hm):
+                hm = hp = hmin = 1.0
+
+            h = np.linspace(min(hm, 0), max(hp, 1), 256)
+            with figure(dirname / f"test_ad_ex_lambert_arg_{name}") as fig:
+                ax = fig.gca()
+
+                ax.plot(h, func(h))
+                ax.plot([hm, hmin, hp], [func(hm), func(hmin), func(hp)], "ro")
+
+
+def test_ad_ex_lambert_limits(*, visualize: bool = True) -> None:
+    from math import gamma
+
+    from pycaputo.integrate_fire.ad_ex import (
+        AD_EX_PARAMS,
+        AdExModel,
+        _evaluate_lambert_coefficients,
+        _find_maximum_time_lambert,
+    )
+
+    alpha = (0.9, 0.4)
+    tn = 0.0
+    dt = 1.0e-2
+
+    def func(ad_ex: AdExModel, tspike: float, r: Array) -> float:
+        h = np.array([
+            gamma(2 - alpha[0]) * (tspike - tn) ** alpha[0],
+            gamma(2 - alpha[1]) * (tspike - tn) ** alpha[1],
+        ])
+
+        (d0, d1, d2), _ = _evaluate_lambert_coefficients(ad_ex, h, r)
+        return float(d2 / d0 * np.exp(-d1 / d0 + 1.0))
+
+    rng = np.random.default_rng(seed=42)
+
+    for name, dim in AD_EX_PARAMS.items():
+        param = dim.nondim(alpha)
+        ad_ex = AdExModel(param)
+
+        y0 = np.array([rng.uniform(param.v_reset, param.v_peak), rng.uniform()])
+        r = np.array([dt**a / gamma(1 - a) * yi for a, yi in zip(alpha, y0)])
+
+        tspike = tn + np.logspace(-10.0, -0.3, 256)
+        f = np.array([func(ad_ex, t, r) for t in tspike])
+        assert np.any(f < 1.0)
+
+        imax = np.argmax(f > 1.0) - 1
+        logger.info("max tspike: t %.12e f %.12e", tspike[imax - 1], f[imax - 1])
+
+        tspike_opt = _find_maximum_time_lambert(ad_ex, tn, r)
+        logger.info("opt tspike: %.12e", tspike_opt)
+        assert tspike[imax - 1] <= tspike_opt <= 1.0, tspike_opt
+
+        if visualize:
+            from pycaputo.utils import figure
+
+            with figure(dirname / f"test_ad_ex_lambert_limits_{name}") as fig:
+                ax = fig.gca()
+
+                ax.plot(tspike, f)
+                ax.plot(tspike_opt, func(ad_ex, tspike_opt, r), "ro")
+                ax.axhline(0.0, color="k", ls="--")
+                ax.axhline(1.0, color="k", ls="--")
+
+
+# }}}
+
+
+# {{{ test_ad_ex_solve
+
+
+def test_ad_ex_solve() -> None:
+    from pycaputo.integrate_fire.ad_ex import (
+        AD_EX_PARAMS,
+        AdExModel,
+        ad_ex_solve,
+        get_ad_ex_parameters,
+    )
+
+    rng = np.random.default_rng(seed=42)
+    dt = 1.0e-2
+    alpha = (0.9, 0.71)
+
+    from math import gamma
+
+    for name in AD_EX_PARAMS:
+        param = get_ad_ex_parameters(name, alpha)
+        ad_ex = AdExModel(param)
+
+        for _ in range(16):
+            t = dt
+            y0 = np.array([rng.uniform(param.v_reset, param.v_peak), rng.uniform()])
+            h = np.array([gamma(2 - a) * dt**a for a in alpha])
+            r = np.array([dt**a / gamma(1 - a) * yi for a, yi in zip(alpha, y0)])
+
+            y = ad_ex_solve(ad_ex, t, y0, h, r)
+            error = y - h * ad_ex.source(t, y) - r
+            e_imag = np.linalg.norm(error.imag)
+            e_real = np.linalg.norm(error.real)
+
+            assert e_imag < 1.0e-15
+            assert e_real < 1.0e-15
+
+        logger.info("[%s] real %.12e imag %.12e", name, e_real, e_imag)
+
+
+# }}}
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        pytest.main([__file__])

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -207,6 +207,15 @@ def test_ad_ex_solve() -> None:
 # }}}
 
 
+# {{{ test_pif_model
+
+
+def test_pif_model() -> None:
+    pass
+
+
+# }}}
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -321,7 +321,7 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
 
     from pycaputo.controller import make_jannelli_controller
     from pycaputo.stepping import evolve
-    from pycaputo.utils import EOCRecorder, gamma
+    from pycaputo.utils import EOCRecorder, gamma, stringify_eoc
 
     tspikes_ref = model.param.constant_spike_times(tfinal, V0=y0[0])
 
@@ -333,8 +333,8 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
 
     logger.info("Found %d spikes", tspikes_ref.size)
 
-    eoct = EOCRecorder(order=1.0)
-    eocy = EOCRecorder(order=2.0 - alpha)
+    eoct = EOCRecorder(order=1.0, name="tspikes")
+    eocy = EOCRecorder(order=2.0 - alpha, name="y")
     for chimin, chimax in resolutions:
         c = make_jannelli_controller(
             tstart,
@@ -390,7 +390,7 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
         logger.info("dt %.12e error %.12e", dtmax, err)
         eocy.add_data_point(dtmax, err)
 
-    logger.info("\n%s\n%s", eoct, eocy)
+    logger.info("\n%s", stringify_eoc(eoct, eocy))
 
     assert eoct.order is not None
     assert eoct.order - 0.25 < eoct.estimated_order < eoct.order + 0.25

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -322,8 +322,8 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
     y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
     from pycaputo.controller import make_jannelli_controller
-    from pycaputo.fode import evolve
-    from pycaputo.utils import EOCRecorder
+    from pycaputo.stepping import evolve
+    from pycaputo.utils import EOCRecorder, gamma
 
     tspikes_ref = model.param.constant_spike_times(tfinal, V0=y0[0])
 
@@ -386,7 +386,7 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
 
         t = np.array(ts[:-2])
         y = np.array(ys).squeeze()[:-2]
-        y_ref = y0 + model.param.current * t**alpha / stepper.gamma1p
+        y_ref = y0 + model.param.current * t**alpha / gamma(1 + stepper.alpha)
 
         dtmax = np.max(np.diff(t))
         err = la.norm(y - y_ref) / la.norm(y_ref)

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -116,7 +116,7 @@ def ad_ex_zero(a: float, tau_w: float, h: Array) -> Array:
     return (1 + (1 + a * h / (h + tau_w)) * h) / h
 
 
-def test_ad_ex_lambert_arg(*, visualize: bool = True) -> None:
+def test_ad_ex_lambert_arg(*, visualize: bool = False) -> None:
     from math import gamma
 
     from pycaputo.integrate_fire.ad_ex import AD_EX_PARAMS
@@ -159,7 +159,7 @@ def test_ad_ex_lambert_arg(*, visualize: bool = True) -> None:
 
 
 @pytest.mark.xfail()
-def test_ad_ex_lambert_limits(*, visualize: bool = True) -> None:
+def test_ad_ex_lambert_limits(*, visualize: bool = False) -> None:
     from math import gamma
 
     from pycaputo.controller import make_jannelli_controller
@@ -200,8 +200,7 @@ def test_ad_ex_lambert_limits(*, visualize: bool = True) -> None:
             derivative_order=alpha,
             control=make_jannelli_controller(chimin=0.1, chimax=1.0),
             y0=(y0,),
-            source=ad_ex.source,
-            model=ad_ex,
+            source=ad_ex,
         )
 
         # check that the solution is actually complex
@@ -274,8 +273,7 @@ def test_ad_ex_solve() -> None:
                 derivative_order=alpha,
                 control=make_jannelli_controller(chimin=0.1, chimax=1.0),
                 y0=(y0,),
-                source=ad_ex.source,
-                model=ad_ex,
+                source=ad_ex,
             )
 
             h = np.array([gamma(2 - a) * dt**a for a in alpha])
@@ -351,8 +349,7 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
             derivative_order=(alpha,),
             control=c,
             y0=(y0,),
-            source=model.source,
-            model=model,
+            source=model,
         )
 
         ts = []

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -114,7 +114,7 @@ def test_ad_ex_lambert_limits(*, visualize: bool = True) -> None:
     from pycaputo.integrate_fire.ad_ex import (
         AD_EX_PARAMS,
         AdExModel,
-        _evaluate_lambert_coefficients,
+        _evaluate_lambert_coefficients,  # noqa: PLC2701
         find_maximum_time_step_lambert,
     )
 


### PR DESCRIPTION
This adds support for some families of integrate-and-fire model:
* the Perfect Integrate-and-Fire (PIF) model
* the Leaky Integrate-and-Fire (LIF) model
* the Exponential Integrate-and-Fire (EIF) model
* and the Adaptive Exponential Integrate-and-Fire (AdEx) model

They're all implemented using an L1 type method that support adaptive time stepping and has some spike time approximation methods.