### PR TITLE
[fode] Implement Trapezoidal method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,10 @@ Features
   in :class:`~pycaputo.quadrature.riemann_liouville.SplineLagrange`. These methods
   require knowledge of the function :math:`f` being integrated, but can obtain
   high order :math:`> 3`.
+* Implement the implicit :class:`~pycaputo.fode.caputo.Trapezoidal` and
+  :class:`~pycaputo.fode.caputo.ExplicitTrapezoidal` methods. These methods are
+  closely related to the standard :class:`~pycaputo.fode.caputo.PECE` method.
+  The implicit method has better stability.
 
 Changes
 ^^^^^^^

--- a/src/pycaputo/fode/caputo.py
+++ b/src/pycaputo/fode/caputo.py
@@ -17,7 +17,7 @@ from pycaputo.fode.product_integration import (
 )
 from pycaputo.history import ProductIntegrationHistory
 from pycaputo.logging import get_logger
-from pycaputo.stepping import advance, gamma1p, gamma2m, make_initial_condition
+from pycaputo.stepping import advance, gamma1p, gamma2m, gamma2p, make_initial_condition
 from pycaputo.utils import Array, StateFunctionT, gamma
 
 logger = get_logger(__name__)
@@ -264,6 +264,165 @@ def _advance_caputo_weighted_euler(
         ynext = m.solve(t, y, fac, fnext)
     else:
         ynext = fnext
+
+    trunc = _truncation_error(m.control, m.alpha, t, ynext, t - dt, y)
+    return AdvanceResult(ynext, trunc, m.source(t, ynext))
+
+
+# }}}
+
+
+# {{{ Trapezoidal
+
+
+@dataclass(frozen=True)
+class Trapezoidal(CaputoProductIntegrationMethod[StateFunctionT]):
+    """The trapezoidal method for discretizing the Caputo derivative.
+
+    This is an implicit method described in [Garrappa2015b]_. It uses a linear
+    interpolant on each time step.
+    """
+
+    source_jac: StateFunctionT | None
+    r"""Jacobian of
+    :attr:`~pycaputo.stepping.FractionalDifferentialEquationMethod.source`.
+    By default, implicit methods use :mod:`scipy` for their root finding,
+    which defines the Jacobian as :math:`J_{ij} = \partial f_i / \partial y_j`.
+    """
+
+    @property
+    def order(self) -> float:
+        return 2.0
+
+    # NOTE: `_get_kwargs` is meant to be overwritten for testing purposes or
+    # some specific application (undocumented for now).
+
+    def _get_kwargs(self, *, scalar: bool = True) -> dict[str, object]:
+        """
+        :returns: additional keyword arguments for :func:`scipy.optimize.root_scalar`.
+            or :func:`scipy.optimize.root`.
+        """
+        if scalar:
+            return {}
+        else:
+            # NOTE: the default hybr does not use derivatives, so use lm instead
+            # FIXME: will need to maybe benchmark these a bit?
+            return {"method": "lm" if self.source_jac else None}
+
+    def solve(self, t: float, y0: Array, c: Array, r: Array) -> Array:
+        """Wrapper around :func:`~pycaputo.implicit.solve` to solve the
+        implicit equation.
+
+        This function should be overwritten for specific applications if better
+        solvers are known. For example, many problems can be solved explicitly
+        or approximated to a very good degree to provide a better *y0*.
+        """
+        from pycaputo.implicit import solve
+
+        return solve(
+            self.source,
+            self.source_jac,
+            t,
+            y0,
+            c,
+            r,
+            **self._get_kwargs(scalar=y0.size == 1),
+        )
+
+
+def _weights_quadrature_trapezoidal(
+    m: CaputoProductIntegrationMethod[StateFunctionT],
+    history: ProductIntegrationHistory,
+    n: int,
+) -> tuple[Array, Array]:
+    # get time history
+    ts = (history.ts[n] - history.ts[: n + 1]).reshape(-1, 1)
+    dt = np.diff(history.ts[:n + 1]).reshape(-1, 1)
+
+    alpha = m.alpha
+    r0 = ts**alpha / gamma1p(m)
+    r1 = ts ** (1.0 + alpha) / gamma2p(m)
+
+    omegal = r1[1:] / dt + r0[:-1] - r1[:-1] / dt
+    omegar = r1[:-1] / dt - r0[1:] - r1[1:] / dt
+
+    return omegal, omegar
+
+
+def _update_caputo_trapezoidal(
+    out: Array,
+    m: CaputoProductIntegrationMethod[StateFunctionT],
+    history: ProductIntegrationHistory,
+    n: int,
+) -> tuple[Array, Array]:
+    assert 0 < n <= len(history)
+    omegal, omegar = _weights_quadrature_trapezoidal(m, history, n)
+    fs = history.storage[:n]
+
+    # add forward terms
+    out += np.einsum("ij,ij->j", omegal, fs)
+    # add backward terms
+    out += np.einsum("ij,ij->j", omegar[:-1], fs[1:])
+
+    return out, omegar[-1].squeeze()
+
+
+@advance.register(Trapezoidal)
+def _advance_caputo_trapezoidal(
+    m: Trapezoidal[StateFunctionT],
+    history: ProductIntegrationHistory,
+    y: Array,
+    dt: Array,
+) -> AdvanceResult:
+    # set next time step
+    n = len(history)
+    tstart = m.control.tstart
+    t = history.ts[n] = history.ts[n - 1] + dt
+
+    # compute solution
+    fnext = np.zeros_like(y)
+    fnext = _update_caputo_initial_condition(fnext, m.y0, t - tstart)
+    fnext, fac = _update_caputo_trapezoidal(fnext, m, history, n)
+
+    # solve `ynext = fac * f(t, ynext) + fnext`
+    ynext = m.solve(t, y, fac, fnext)
+
+    trunc = _truncation_error(m.control, m.alpha, t, ynext, t - dt, y)
+    return AdvanceResult(ynext, trunc, m.source(t, ynext))
+
+
+@dataclass(frozen=True)
+class ExplicitTrapezoidal(CaputoProductIntegrationMethod[StateFunctionT]):
+    """An explicit trapezoidal method for discretizing the Caputo derivative.
+
+    This is an explicit method described in [Garrappa2015b]_. Unlike
+    :class:`Trapezoidal`, the last step is estimate by extrapolation, making this
+    an explicit method instead with decreased stability.
+    """
+
+    @property
+    def order(self) -> float:
+        return 1.0 + self.smallest_derivative_order
+
+
+@advance.register(ExplicitTrapezoidal)
+def _advance_caputo_explicit_trapezoidal(
+    m: ExplicitTrapezoidal[StateFunctionT],
+    history: ProductIntegrationHistory,
+    y: Array,
+    dt: Array,
+) -> AdvanceResult:
+    # set next time step
+    n = len(history)
+    tstart = m.control.tstart
+    t = history.ts[n] = history.ts[n - 1] + dt
+
+    # compute solution
+    fnext = np.zeros_like(y)
+    fnext = _update_caputo_initial_condition(fnext, m.y0, t - tstart)
+    fnext, _ = _update_caputo_trapezoidal(fnext, m, history, n)
+
+    ynext = fnext
 
     trunc = _truncation_error(m.control, m.alpha, t, ynext, t - dt, y)
     return AdvanceResult(ynext, trunc, m.source(t, ynext))

--- a/src/pycaputo/fode/caputo.py
+++ b/src/pycaputo/fode/caputo.py
@@ -434,11 +434,11 @@ def _advance_caputo_explicit_trapezoidal(
         fm1 = history.storage[n - 1]
         fm2 = history.storage[n - 2]
 
-        omegal = -ts1 ** (1 + m.alpha) / gamma(2 + m.alpha) / dt2
+        omegal = -(ts1 ** (1 + m.alpha)) / gamma(2 + m.alpha) / dt2
         ynext += (omega + omegal) * fm2
-        omegar = (
-            ts1 ** (1 + m.alpha) / gamma(2 + m.alpha) / dt2
-            + ts1**m.alpha / gamma(1 + m.alpha))
+        omegar = ts1 ** (1 + m.alpha) / gamma(2 + m.alpha) / dt2 + ts1**m.alpha / gamma(
+            1 + m.alpha
+        )
         ynext += omegar * fm1
 
     trunc = _truncation_error(m.control, m.alpha, t, ynext, t - dt, y)

--- a/tests/test_fode_caputo.py
+++ b/tests/test_fode_caputo.py
@@ -171,11 +171,12 @@ def test_fode_caputo(
 
     for n in [32, 64, 128, 256, 512]:
         m = factory(alpha, n)
+        dtinit = getattr(m.control, "dt", None)
 
         with BlockTimer(name=m.name) as bt:
             ts = []
             ys = []
-            for event in evolve(m, dtinit=m.control.dt):
+            for event in evolve(m, dtinit=dtinit):
                 if isinstance(event, StepFailed):
                     raise ValueError("Step update failed")
                 elif isinstance(event, StepCompleted):

--- a/tests/test_fode_caputo.py
+++ b/tests/test_fode_caputo.py
@@ -143,6 +143,7 @@ def fode_factory(
         fode_factory(caputo.ForwardEuler),
         fode_factory(caputo.WeightedEuler, theta=0.0),
         fode_factory(caputo.WeightedEuler, theta=0.5),
+        fode_factory(caputo.Trapezoidal),
         fode_factory(caputo.PECE, corrector_iterations=1),
         # FIXME: this does not converge to the correct order with one iteration
         fode_factory(caputo.PEC, corrector_iterations=2),

--- a/tests/test_fode_caputo.py
+++ b/tests/test_fode_caputo.py
@@ -144,6 +144,7 @@ def fode_factory(
         fode_factory(caputo.WeightedEuler, theta=0.0),
         fode_factory(caputo.WeightedEuler, theta=0.5),
         fode_factory(caputo.Trapezoidal),
+        # fode_factory(caputo.ExplicitTrapezoidal),
         fode_factory(caputo.PECE, corrector_iterations=1),
         # FIXME: this does not converge to the correct order with one iteration
         fode_factory(caputo.PEC, corrector_iterations=2),
@@ -174,7 +175,7 @@ def test_fode_caputo(
         with BlockTimer(name=m.name) as bt:
             ts = []
             ys = []
-            for event in evolve(m):
+            for event in evolve(m, dtinit=m.control.dt):
                 if isinstance(event, StepFailed):
                     raise ValueError("Step update failed")
                 elif isinstance(event, StepCompleted):


### PR DESCRIPTION
This implements two variants of the trapezoidal method from [Garrappa2015](http://dx.doi.org/10.1016/j.matcom.2013.09.012):
* The standard implicit method
* An explicit method obtained by extrapolation. Note that the PECE method is also an explicit version of the trapezoidal method with much better properties.