### PR TITLE
Support different orders in PECE schemes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+pycaputo (TDB)
+--------------
+
+Features
+^^^^^^^^
+
+* Extend :class:`~pycaputo.fode.caputo.PECE`, :class:`~pycaputo.fode.caputo.PEC`
+  and :class:`~pycaputo.fode.caputo.ModifiedPECE` to support systems with different
+  orders (:ghpr:`46` and :ghissue:`17`).
+
+Fixes
+^^^^^
+
+* Fix convergence of :class:`~pycaputo.fode.caputo.ModifiedPECE` (:ghissue:`15`).
+
 pycaputo 0.6.0 (May 30, 2024)
 -----------------------------
 

--- a/tests/test_fode_caputo.py
+++ b/tests/test_fode_caputo.py
@@ -230,6 +230,10 @@ def test_fode_caputo(
     [
         fode_factory(caputo.ForwardEuler, nterms=3),
         fode_factory(caputo.WeightedEuler, theta=0.5, nterms=3),
+        fode_factory(caputo.Trapezoidal, nterms=3),
+        fode_factory(caputo.ExplicitTrapezoidal, nterms=3),
+        fode_factory(caputo.PECE, corrector_iterations=1, nterms=3),
+        fode_factory(caputo.ModifiedPECE, corrector_iterations=1, nterms=3),
     ],
 )
 def test_fode_caputo_system(


### PR DESCRIPTION
Updates all the Predictor-Corrector schemes (PECE / PEC / ModifedPECE) to support different orders alpha by leveraging the Trapezoidal method helpers.

Fixes #15. 
Fixes #17.