### PR TITLE
Rework derivative discretizations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,29 @@
 Changelog
 =========
 
+pycaputo (TBD)
+--------------
+
+Features
+^^^^^^^^
+
+* Add a :mod:`pycaputo.typing` module containing some helpful typing definitions
+  (mostly previously in :mod:`pycaputo.utils`).
+* Reworked :func:`~functools.singledispatch` functions for
+  :class:`~pycaputo.differentiation.DerivativeMethod`. We now have
+  :func:`~pycaputo.differentiation.quadrature_weights`,
+  :func:`~pycaputo.differentiation.differentiation_matrix`,
+  :func:`~pycaputo.differentiation.diffs`, and
+  :func:`~pycaputo.differentiation.diff`. Not all of these need to be implemented
+  and most methods are not ported yet. Currently only the
+  :class:`~pycaputo.differentiation.caputo.L1` and
+  :class:`~pycaputo.differentiation.caputo.L2` methods implement these new functions.
+* Introduce some more specific methods for the Caputo derivative. The
+  :class:`~pycaputo.differentiation.caputo.L2F` uses the L2 method with function
+  evaluations outside of the interval of definition. The
+  :class:`~pycaputo.differentiation.caputo.LXD` allows evaluating arbitrary
+  Caputo derivatives when the integer derivatives are known.
+
 pycaputo 0.7.0 (July 13, 2024)
 ------------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,12 @@ Features
   :class:`~pycaputo.differentiation.caputo.LXD` allows evaluating arbitrary
   Caputo derivatives when the integer derivatives are known.
 
+Changes
+^^^^^^^
+
+* Renamed `pycaputo.differentiation.caputo.SpectralJacobi` to
+  :class:`~pycaputo.differentiation.caputo.Jacobi`.
+
 pycaputo 0.7.0 (July 13, 2024)
 ------------------------------
 

--- a/docs/guide_differentiation.rst
+++ b/docs/guide_differentiation.rst
@@ -52,19 +52,20 @@ also have
   pleasant way of reusing and analyzing the weights.
 
 * :func:`~pycaputo.differentiation.differentiation_matrix`: a function that
-  gathers all the quadrature weights into a matrix operator.
+  gathers all the quadrature weights into a matrix operator. By default, this
+  function is implemented in terms of ``quadrature_weights``, but can be
+  overwritten by more efficient implementations.
 
-* :func:`~pycaputo.differentiation.diffs`: a method very similar to
-  :func:`~pycaputo.differentiation.diff`, but that only computes the fractional
-  operator at a given point on the grid. Note that not all methods can efficiently
-  evaluate the fractional operator at a single point (e.g. global spectral methods),
-  so they should not implement this functionality.
+* :func:`~pycaputo.differentiation.diffs`: a function that computes the
+  fractional operator at a given point on a grid. Note that not all methods can
+  efficiently evaluate the fractional operator at a single point (e.g. global
+  spectral methods), so they should not implement this functionality.
 
-* :func:`~pycaputo.differentiation.diff`: for many methods, the ``diff`` function
-  can be a simple wrapper around :func:`~pycaputo.differentiation.diffs`, but this
-  doesn't always make sense. For example, if we want to compute the Caputo
-  fractional derivative on a uniform grid, this can be evaluated more efficiently
-  using the FFT.
+* :func:`~pycaputo.differentiation.diff`: a function that computes the fractional
+  operator at a set of points. By default this is implemented in terms of the
+  ``diffs`` function, but this doesn't always make sense. For example, if we want
+  to compute the Caputo fractional derivative on a uniform grid, this can be
+  evaluated more efficiently using the FFT.
 
 In general, we require that the :func:`~pycaputo.differentiation.diff` function be
 implemented for all available methods, while the remaining functions are optional.

--- a/docs/guide_differentiation.rst
+++ b/docs/guide_differentiation.rst
@@ -51,6 +51,9 @@ also have
   should not implement this method. However, for those that can, this offers a
   pleasant way of reusing and analyzing the weights.
 
+* :func:`~pycaputo.differentiation.differentiation_matrix`: a function that
+  gathers all the quadrature weights into a matrix operator.
+
 * :func:`~pycaputo.differentiation.diffs`: a method very similar to
   :func:`~pycaputo.differentiation.diff`, but that only computes the fractional
   operator at a given point on the grid. Note that not all methods can efficiently
@@ -58,11 +61,13 @@ also have
   so they should not implement this functionality.
 
 * :func:`~pycaputo.differentiation.diff`: for many methods, the ``diff`` function
-  is a simple wrapper around :func:`~pycaputo.differentiation.diffs`, but this
+  can be a simple wrapper around :func:`~pycaputo.differentiation.diffs`, but this
   doesn't always make sense. For example, if we want to compute the Caputo
   fractional derivative on a uniform grid, this can be evaluated more efficiently
   using the FFT.
 
+In general, we require that the :func:`~pycaputo.differentiation.diff` function be
+implemented for all available methods, while the remaining functions are optional.
 These methods are all registered with the :func:`~functools.singledispatch` mechanism.
 An example setup is provided below.
 

--- a/docs/guide_differentiation.rst
+++ b/docs/guide_differentiation.rst
@@ -1,8 +1,8 @@
 A New Differentiation Method
 ============================
 
-Computing the derivative of a function can be done in two ways. The recommended
-method (with included magic) is calling :func:`pycaputo.diff` as
+Computing the fractional derivative of a function can be done in two ways. The
+recommended method (with included magic) is calling :func:`pycaputo.diff` as
 
 .. code:: python
 
@@ -10,8 +10,8 @@ method (with included magic) is calling :func:`pycaputo.diff` as
 
 which will automatically select an appropriate method to use given the point set
 ``p`` and the order ``alpha`` (see also
-:func:`pycaputo.differentiation.guess_method_for_order`). To manually call a
-specific method, use :func:`pycaputo.differentiation.diff` instead as
+:func:`~pycaputo.differentiation.guess_method_for_order`). To manually call a
+specific method, use the lower level :func:`pycaputo.differentiation.diff` instead as
 
 .. code:: python
 
@@ -40,8 +40,31 @@ abstract methods of the base class. For example,
     :start-after: [class-definition-start]
     :end-before: [class-definition-end]
 
-Then, we can implement the :func:`~pycaputo.differentiation.diff` method by
-registering it with the :func:`~functools.singledispatch` mechanism as
+Then, we have defined a set of functions useful for working with a discrete
+fractional operator approximations. As mentioned above, the main functionality
+is provided by the :func:`~pycaputo.differentiation.diff` method. However, we
+also have
+
+* :func:`~pycaputo.differentiation.quadrature_weights`: a function that can provide
+  the underlying quadrature weights for a given method. Note that not all methods
+  can be efficiently expressed as a weighted sum with quadrature weights, so they
+  should not implement this method. However, for those that can, this offers a
+  pleasant way of reusing and analyzing the weights.
+
+* :func:`~pycaputo.differentiation.diffs`: a method very similar to
+  :func:`~pycaputo.differentiation.diff`, but that only computes the fractional
+  operator at a given point on the grid. Note that not all methods can efficiently
+  evaluate the fractional operator at a single point (e.g. global spectral methods),
+  so they should not implement this functionality.
+
+* :func:`~pycaputo.differentiation.diff`: for many methods, the ``diff`` function
+  is a simple wrapper around :func:`~pycaputo.differentiation.diffs`, but this
+  doesn't always make sense. For example, if we want to compute the Caputo
+  fractional derivative on a uniform grid, this can be evaluated more efficiently
+  using the FFT.
+
+These methods are all registered with the :func:`~functools.singledispatch` mechanism.
+An example setup is provided below.
 
 .. literalinclude:: ../examples/guide-differentiation.py
     :language: python

--- a/docs/misc_others.rst
+++ b/docs/misc_others.rst
@@ -14,13 +14,13 @@ Logging
 Typing
 ------
 
-.. automodule:: pycaputo.typing
-
 .. class:: pycaputo.utils.P
 
     A generic invarint :class:`typing.ParamSpec`.
 
     alias of ParamSpec('P')
+
+.. automodule:: pycaputo.typing
 
 Utils
 -----

--- a/examples/caputo-derivative-l1-spectrum.py
+++ b/examples/caputo-derivative-l1-spectrum.py
@@ -24,7 +24,7 @@ from pycaputo.differentiation import quadrature_weights
 from pycaputo.differentiation.caputo import L1
 from pycaputo.grid import make_uniform_points
 from pycaputo.logging import get_logger
-from pycaputo.utils import Array
+from pycaputo.typing import Array
 
 logger = get_logger("caputo_derivative_l1_spectrum")
 

--- a/examples/caputo-derivative-l1-spectrum.py
+++ b/examples/caputo-derivative-l1-spectrum.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+r"""Computes the matrix operator for the Caputo derivative and look at its
+spectrum for various values of :math:`\alpha`.
+
+The spectrum of the matrix is quite boring, since the matrix itself is lower
+triangular, so all the eigenvalues are on the diagonal. From the method, we know
+that
+
+.. math::
+
+    W_{n, n} = \frac{1}{\Gamma(2 - \alpha)} \frac{1}{\Delta x^\alpha}.
+
+i.e. the diagonal is constant. This mostly serves as an example of how the
+matrices can be constructed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pycaputo.differentiation import quadrature_weights
+from pycaputo.differentiation.caputo import L1
+from pycaputo.grid import make_uniform_points
+from pycaputo.logging import get_logger
+from pycaputo.utils import Array
+
+logger = get_logger("caputo_derivative_l1_spectrum")
+
+
+# {{{ matrix
+
+
+def get_l1_matrix(alpha: float, *, n: int, a: float, b: float) -> Array:
+    W = np.zeros((n, n))
+
+    meth = L1(alpha=alpha)
+    points = make_uniform_points(n, a=0, b=1)
+
+    for i in range(1, n):
+        W[i, : i + 1] = quadrature_weights(meth, points, i + 1)
+    W[0, 0] = W[1, 1]
+
+    return W
+
+
+# }}}
+
+
+# {{{ conditioning
+
+n = 256
+alphas = [0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
+
+for alpha in alphas:
+    W = get_l1_matrix(alpha, n=n, a=0.0, b=1.0)
+    kappa = np.linalg.cond(W)
+    logger.info("alpha = %.2f kappa = %.8e", alpha, kappa)
+
+# }}}
+
+# {{{ plot
+
+try:
+    import matplotlib  # noqa: F401
+except ImportError as exc:
+    raise SystemExit(0) from exc
+
+from pycaputo.utils import figure, set_recommended_matplotlib
+
+set_recommended_matplotlib()
+
+with figure("caputo-derivative-l1-spectrum") as fig:
+    ax = fig.gca()
+
+    for alpha in alphas:
+        W = get_l1_matrix(alpha, n=n, a=0.0, b=1.0)
+        sigma = np.linalg.eigvals(W)
+        ax.plot(sigma.real, sigma.imag, "o")
+
+    ax.set_xlabel(r"$\Re$")
+    ax.set_ylabel(r"$\Im$")
+
+# }}}

--- a/examples/caputo-derivative-quadratic.py
+++ b/examples/caputo-derivative-quadratic.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo.differentiation import diff
-from pycaputo.differentiation.caputo import SpectralJacobi
+from pycaputo.differentiation.caputo import Jacobi
 from pycaputo.grid import make_jacobi_gauss_lobatto_points
 from pycaputo.typing import Array
 
@@ -58,7 +58,7 @@ with figure("caputo-derivative-quadratic") as fig:
     p = make_jacobi_gauss_lobatto_points(32, a=0.0, b=2.0)
 
     for alpha in alphas:
-        method = SpectralJacobi(alpha=alpha)
+        method = Jacobi(alpha=alpha)
 
         df_num = diff(method, f, p)
         ax.plot(p.x, df_num, color="k", alpha=0.2)

--- a/examples/caputo-gradient-spectral.py
+++ b/examples/caputo-gradient-spectral.py
@@ -53,7 +53,7 @@ def df(x: Array, alpha: float) -> Array:
 from pycaputo.differentiation import caputo
 
 alpha = 0.9
-method = caputo.SpectralJacobi(alpha=0.9)
+method = caputo.Jacobi(alpha=0.9)
 
 # make a set of points at which to evaluate the gradient
 rng = np.random.default_rng(42)

--- a/examples/guide-differentiation.py
+++ b/examples/guide-differentiation.py
@@ -42,7 +42,28 @@ class RiemannLiouvilleDerivativeMethod(DerivativeMethod):
 # {{{
 
 # [register-start]
-from pycaputo.differentiation import diff
+from pycaputo.differentiation import diff, diffs, quadrature_weights
+
+
+@quadrature_weights.register(RiemannLiouvilleDerivativeMethod)
+def _quadrature_weights_rl(
+    m: RiemannLiouvilleDerivativeMethod,
+    p: Points,
+    n: int,
+) -> Array:
+    # ... add an actual implementation here ...
+    return np.zeros(n, dtype=p.x.dtype)
+
+
+@diffs.register(RiemannLiouvilleDerivativeMethod)
+def _diffs_rl(
+    m: RiemannLiouvilleDerivativeMethod,
+    f: ArrayOrScalarFunction,
+    p: Points,
+) -> Array:
+    fx = f(p.x) if callable(f) else f
+    # ... add an actual implementation here ...
+    return np.zeros_like(fx)
 
 
 @diff.register(RiemannLiouvilleDerivativeMethod)

--- a/examples/guide-differentiation.py
+++ b/examples/guide-differentiation.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from pycaputo.derivatives import RiemannLiouvilleDerivative, Side
 from pycaputo.grid import Points
-from pycaputo.typing import Array, ArrayOrScalarFunction
+from pycaputo.typing import Array, ArrayOrScalarFunction, Scalar
 
 # {{{
 
@@ -42,7 +42,12 @@ class RiemannLiouvilleDerivativeMethod(DerivativeMethod):
 # {{{
 
 # [register-start]
-from pycaputo.differentiation import diff, diffs, quadrature_weights
+from pycaputo.differentiation import (
+    diff,
+    differentiation_matrix,
+    diffs,
+    quadrature_weights,
+)
 
 
 @quadrature_weights.register(RiemannLiouvilleDerivativeMethod)
@@ -55,15 +60,24 @@ def _quadrature_weights_rl(
     return np.zeros(n, dtype=p.x.dtype)
 
 
+@differentiation_matrix.register(RiemannLiouvilleDerivativeMethod)
+def _differentiation_matrix_rl(
+    m: RiemannLiouvilleDerivativeMethod,
+    p: Points,
+) -> Array:
+    # ... add an actual implementation here ...
+    return np.zeros((p.size, p.size), dtype=p.x.dtype)
+
+
 @diffs.register(RiemannLiouvilleDerivativeMethod)
 def _diffs_rl(
     m: RiemannLiouvilleDerivativeMethod,
     f: ArrayOrScalarFunction,
     p: Points,
-) -> Array:
-    fx = f(p.x) if callable(f) else f
+    n: int,
+) -> Scalar:
     # ... add an actual implementation here ...
-    return np.zeros_like(fx)
+    return np.array(0.0)
 
 
 @diff.register(RiemannLiouvilleDerivativeMethod)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "differint",
+    "differint @ git+https://github.com/alexfikl/differint.git@fix-l2-index#egg=differint",
     "doc8",
     "matplotlib",
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "typing-extensions; python_version<'3.10'",
 ]
 optional-dependencies.dev = [
-    "differint",
     "differint @ git+https://github.com/alexfikl/differint.git@fix-l2-index#egg=differint",
     "doc8",
     "matplotlib",
@@ -69,6 +68,9 @@ optional-dependencies.vis = [
 ]
 urls.Documentation = "https://pycaputo.readthedocs.io"
 urls.Repository = "https://github.com/alexfikl/pycaputo"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,7 @@ contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-differint==1.0.0
+differint @ git+https://github.com/alexfikl/differint.git@ab981f6bcd9435a46d85470a1ab01cbcf536837d#egg=differint
     # via pycaputo (pyproject.toml)
 doc8==1.1.1
     # via pycaputo (pyproject.toml)
@@ -183,9 +183,9 @@ typos==1.23.6
     # via pycaputo (pyproject.toml)
 urllib3==2.2.2
     # via requests
-uv==0.2.34
+uv==0.2.35
     # via pycaputo (pyproject.toml)
-zipp==3.19.2 ; python_version < '3.10'
+zipp==3.20.0 ; python_version < '3.10'
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/src/pycaputo/__init__.py
+++ b/src/pycaputo/__init__.py
@@ -29,8 +29,7 @@ def diff(
     :arg d: a fractional operator. If this is just a number, the standard
         Caputo derivative will be used.
     """
-    from pycaputo.differentiation import diff as _diff
-    from pycaputo.differentiation import guess_method_for_order
+    import pycaputo.differentiation as fracd
 
     if d is None:
         raise ValueError("'d' is required if 'method is not given")
@@ -38,9 +37,9 @@ def diff(
     if not isinstance(d, FractionalOperator):
         d = CaputoDerivative(d, side=Side.Left)
 
-    m = guess_method_for_order(p, d)
+    m = fracd.guess_method_for_order(p, d)
 
-    return _diff(m, f, p)
+    return fracd.diff(m, f, p)
 
 
 def quad(
@@ -56,8 +55,7 @@ def quad(
     :arg d: a fractional operator. If this is just a number, the standard
         Riemann-Liouville integral will be used.
     """
-    from pycaputo.quadrature import guess_method_for_order
-    from pycaputo.quadrature import quad as _quad
+    import pycaputo.quadrature as fracq
 
     if d is None:
         raise ValueError("'d' is required if 'method' is not given")
@@ -65,9 +63,9 @@ def quad(
     if not isinstance(d, FractionalOperator):
         d = RiemannLiouvilleDerivative(d, side=Side.Left)
 
-    m = guess_method_for_order(p, d)
+    m = fracq.guess_method_for_order(p, d)
 
-    return _quad(m, f, p)
+    return fracq.quad(m, f, p)
 
 
 def grad(
@@ -118,12 +116,12 @@ def grad(
     def make_component_p(i: tuple[int, ...]) -> Points:
         return p.translate(a[i], x[i])
 
-    from pycaputo.differentiation import diff as _diff
+    import pycaputo.differentiation as fracd
 
     result = np.empty_like(x)
     for i in np.ndindex(x.shape):
         # FIXME: this should just compute the gradient at -1
-        result[i] = _diff(m, make_component_f(i), make_component_p(i))[-1]
+        result[i] = fracd.diff(m, make_component_f(i), make_component_p(i))[-1]
 
     return result
 

--- a/src/pycaputo/derivatives.py
+++ b/src/pycaputo/derivatives.py
@@ -51,7 +51,7 @@ class RiemannLiouvilleDerivative(FractionalOperator):
     alpha: float
     """Order of the Riemann-Liouville derivative."""
 
-    side: Side
+    side: Side = Side.Left
     """Side on which to compute the derivative."""
 
     @property
@@ -83,7 +83,7 @@ class CaputoDerivative(FractionalOperator):
     alpha: float
     """Order of the Caputo derivative."""
 
-    side: Side
+    side: Side = Side.Left
     """Side on which to compute the derivative."""
 
     @property
@@ -114,7 +114,7 @@ class GrunwaldLetnikovDerivative(FractionalOperator):
     alpha: float
     """Order of the Grünwald-Letnikov derivative."""
 
-    side: Side
+    side: Side = Side.Left
     """Side on which to compute the derivative."""
 
     @property
@@ -143,7 +143,7 @@ class HadamardDerivative(FractionalOperator):
     alpha: float
     """Order of the Hadamard derivative."""
 
-    side: Side
+    side: Side = Side.Left
     """Side on which to compute the derivative."""
 
     @property
@@ -172,7 +172,7 @@ class CaputoHadamardDerivative(FractionalOperator):
     alpha: float
     """Order of the Caputo-Hadamard derivative."""
 
-    side: Side
+    side: Side = Side.Left
     """Side on which to compute the derivative."""
 
     @property

--- a/src/pycaputo/differentiation/__init__.py
+++ b/src/pycaputo/differentiation/__init__.py
@@ -3,8 +3,13 @@
 
 from __future__ import annotations
 
-from pycaputo.derivatives import FractionalOperator, Side
-from pycaputo.differentiation.base import DerivativeMethod, diff
+from pycaputo.derivatives import FractionalOperator
+from pycaputo.differentiation.base import (
+    DerivativeMethod,
+    diff,
+    diffs,
+    quadrature_weights,
+)
 from pycaputo.grid import Points
 
 
@@ -22,7 +27,7 @@ def guess_method_for_order(
 
     :arg p: a set of points on which to evaluate the fractional operator.
     :arg d: a fractional operator to discretize. If only a float is given, the
-        common Caputo derivative is used.
+        common (left) Caputo derivative is used.
     """
     from pycaputo import grid
     from pycaputo.derivatives import CaputoDerivative, RiemannLiouvilleDerivative
@@ -31,7 +36,7 @@ def guess_method_for_order(
 
     m: DerivativeMethod | None = None
     if not isinstance(d, FractionalOperator):
-        d = CaputoDerivative(alpha=d, side=Side.Left)
+        d = CaputoDerivative(alpha=d)
 
     if isinstance(d, CaputoDerivative):
         if isinstance(p, grid.JacobiGaussLobattoPoints):
@@ -61,5 +66,7 @@ def guess_method_for_order(
 __all__ = (
     "DerivativeMethod",
     "diff",
+    "diffs",
     "guess_method_for_order",
+    "quadrature_weights",
 )

--- a/src/pycaputo/differentiation/__init__.py
+++ b/src/pycaputo/differentiation/__init__.py
@@ -109,7 +109,7 @@ def diffs_fallback(
 
     .. warning::
 
-        Falling back to the :func:`~pycaputo.differentiation.diff`` function
+        Falling back to the :func:`~pycaputo.differentiation.diff` function
         will be significantly slower, since all the points on the grid *p* are
         evaluated. Use this function with care.
     """

--- a/src/pycaputo/differentiation/__init__.py
+++ b/src/pycaputo/differentiation/__init__.py
@@ -42,7 +42,7 @@ def guess_method_for_order(
         if isinstance(p, grid.JacobiGaussLobattoPoints):
             m = caputo.SpectralJacobi(d.alpha)
         elif 0 < d.alpha < 1:
-            if isinstance(p, grid.UniformMidpoints):
+            if isinstance(p, grid.MidPoints):
                 m = caputo.ModifiedL1(d.alpha)
             else:
                 m = caputo.L1(d.alpha)

--- a/src/pycaputo/differentiation/__init__.py
+++ b/src/pycaputo/differentiation/__init__.py
@@ -45,7 +45,7 @@ def guess_method_for_order(
 
     if isinstance(d, CaputoDerivative):
         if isinstance(p, grid.JacobiGaussLobattoPoints):
-            m = caputo.SpectralJacobi(d.alpha)
+            m = caputo.Jacobi(d.alpha)
         elif 0 < d.alpha < 1:
             if isinstance(p, grid.MidPoints):
                 m = caputo.ModifiedL1(d.alpha)

--- a/src/pycaputo/differentiation/__init__.py
+++ b/src/pycaputo/differentiation/__init__.py
@@ -14,7 +14,7 @@ from pycaputo.differentiation.base import (
     quadrature_weights,
 )
 from pycaputo.grid import Points
-from pycaputo.utils import Array, ArrayOrScalarFunction, Scalar
+from pycaputo.typing import Array, ArrayOrScalarFunction, Scalar
 
 
 def guess_method_for_order(

--- a/src/pycaputo/differentiation/__init__.py
+++ b/src/pycaputo/differentiation/__init__.py
@@ -160,7 +160,7 @@ def diff_fallback(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> A
         pass
 
     n = 1
-    df1 = diffs(m, f, p, n + 1)
+    df1 = np.array(diffs(m, f, p, n + 1))
     df = np.empty((p.size, *df1.shape), dtype=df1.dtype)
     df[0] = np.nan
     df[1] = df1

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -89,7 +89,9 @@ def differentiation_matrix(m: DerivativeMethod, p: Points) -> Array:
     """
     n = p.size
     W = np.zeros((n, n), dtype=p.dtype)
-    W[0, 0] = np.nan
+
+    # NOTE: make it very obvious that the first row is garbage
+    W[0, :] = np.nan
 
     try:
         for i in range(1, W.shape[0]):

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -7,8 +7,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import singledispatch
 
-import numpy as np
-
 from pycaputo.derivatives import FractionalOperator
 from pycaputo.grid import Points
 from pycaputo.typing import Array, ArrayOrScalarFunction, Scalar
@@ -50,15 +48,42 @@ def quadrature_weights(m: DerivativeMethod, p: Points, n: int) -> Array:
     .. note::
 
         Not all methods can compute the weights for a single evaluation in
-        this fashion. This function is mainly implemented for methods where the
-        *nth* row can be computed efficiently.
+        this fashion. This function should be implemented for methods where the
+        *nth* row of :math:`w` can be computed efficiently. Other methods may
+        implement :func:`differentiation_matrix` instead.
+
+    The weights can also be constructed using :func:`differentiation_matrix`, if
+    implemented. For a safe function with this fallback, see
+    :func:`~pycaputo.differentiation.quadrature_weights_fallback`.
 
     :arg p: a grid on which to compute the quadrature weights for the point ``p.x[n]``.
     :arg n: the index of the point within *p*.
     """
+
     raise NotImplementedError(
         f"Cannot evaluate quadrature weights for method '{type(m).__name__}' "
         "('quadrature_weights' is not implemented)"
+    )
+
+
+@singledispatch
+def differentiation_matrix(m: DerivativeMethod, p: Points) -> Array:
+    """Evaluate the differentiation matrix for the method *m* at points *p*.
+
+    Without additional knowledge, the value of the derivative at *p.a* is not
+    known. Therefore, the first row of the matrix should not be used in computation.
+
+    This matrix can also be constructed using :func:`quadrature_weights`, if
+    implemented. For a safe function with this fallback, see
+    :func:`~pycaputo.differentiation.differentiation_matrix_fallback`.
+
+    :returns: a two-dimensional array of shape ``(n, n)``, where *n* is the
+        number of points in *p*.
+    """
+
+    raise NotImplementedError(
+        f"Cannot evaluate quadrature weights for method '{type(m).__name__}' "
+        "('differentiation_matrix' is not implemented)"
     )
 
 
@@ -71,53 +96,32 @@ def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points, n: int) -> S
     This is in contract to :func:`diff`, which evaluates the fractional derivative
     at all the points in the grid *p*.
 
-    .. note::
+    The function *f* can be provided as a callable of as an array of values
+    evaluated on the grid *p*. However, not all methods support both variants
+    (e.g. if they require evaluating the function at additional points).
 
-        The function *f* can be provided as a callable of as an array of values
-        evaluated on the grid *p*. However, not all methods support both variants
-        (e.g. if they require evaluating the function at additional points).
+    The function values can also be obtained from :func:`diff` directly, if
+    implemented. For a safe function with this fallback, see
+    :func:`~pycaputo.differentiation.diffs_fallback`.
 
     :arg m: method used to evaluate the derivative.
     :arg f: a simple function for which to evaluate the derivative.
     :arg p: an array of points at which to evaluate the derivative.
     """
-    try:
-        result = diff(m, f, p)
-    except NotImplementedError:
-        raise NotImplementedError(
-            "Cannot evaluate pointwise fractional derivative with method "
-            f"'{type(m).__name__}' ('diffs' is not implemented)"
-        ) from None
-
-    from warnings import warn
-
-    warn(
-        f"'diffs' is not implemented for '{type(m).__name__}' (aka '{m.name}'). "
-        "Falling back to 'diff', which is likely significantly slower! Use "
-        "'diff' directly if this is acceptable.",
-        stacklevel=2,
+    raise NotImplementedError(
+        "Cannot evaluate pointwise fractional derivative with method "
+        f"'{type(m).__name__}' ('diffs' is not implemented)"
     )
-
-    if not 0 <= n <= p.size:
-        raise IndexError(f"Index 'n' out of range: 0 <= {n} < {p.size}")
-
-    return np.array(result[n])
 
 
 @singledispatch
 def diff(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
     """Evaluate the fractional derivative of *f* at *p* using method *m*.
 
-    This function uses :func:`diffs` to evaluate the fractional derivative at
-    all the points in *p*. In most cases it is a trivial wrapper.
+    The function values can also be obtained from :func:`diffs` directly, if
+    implemented. For a safe function with this fallback, see
+    :func:`~pycaputo.differentiation.diff_fallback`.
 
-    .. note::
-
-        All methods are expected to implement this method, while
-        :func:`quadrature_weights` and :func:`diffs` are optional and not
-        supported by all methods.
-
-    :arg m: method used to evaluate the derivative.
     :arg f: a simple function for which to evaluate the derivative.
     :arg p: an array of points at which to evaluate the derivative.
     """
@@ -125,39 +129,3 @@ def diff(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
         f"Cannot evaluate fractional derivative with method '{type(m).__name__}' "
         "('diff' is not implemented)"
     )
-
-
-def quadrature_matrix(m: DerivativeMethod, p: Points, w00: float = 0.0) -> Array:
-    """Evaluate the quadrature matrix for a given method *m* at points *p*.
-
-    This requires that the method implements the :func:`quadrature_weights`. As
-    fractional operator are usually convolutional, this results in a lower
-    triangular matrix.
-
-    The value of the derivative at ``p.a`` is not defined. The value of the
-    matrix at ``W[0, 0]`` can be controlled using *w00*, which is set to 0 by
-    default. This default choice results in a singular operator and may not
-    always be desired.
-
-    Using this matrix operator, we can evaluate the derivative equivalently as
-
-    .. code:: python
-
-        mat = quadrature_matrix(m, p)
-
-        df_mat = mat @ f
-        df_fun = diff(m, f, p)
-        assert np.allclose(df_mat, df_fun)
-
-    :returns: a two-dimensional array of shape ``(n, n)``, where *n* is the
-        number of points in *p*.
-    """
-
-    n = p.size
-    W = np.zeros((n, n))
-    W[0, 0] = w00
-
-    for i in range(1, n):
-        W[i, : i + 1] = quadrature_weights(m, p, i + 1)
-
-    return W

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import singledispatch
 
+import numpy as np
+
 from pycaputo.derivatives import FractionalOperator
 from pycaputo.grid import Points
 from pycaputo.typing import Array, ArrayOrScalarFunction, Scalar
@@ -45,22 +47,29 @@ def quadrature_weights(m: DerivativeMethod, p: Points, n: int) -> Array:
     function. In some cases of interest, e.g. uniform, it is sufficient to
     compute the :math:`w_{N, k}` row and perform the convolution by FFT.
 
-    :arg p: a grid on which to compute the quadrature weights at the point
-        ``p.x[n]``.
+    .. note::
+
+        Not all methods can compute the weights for a single evaluation in
+        this fashion. This function is mainly implemented for methods where the
+        *nth* row can be computed efficiently.
+
+    :arg p: a grid on which to compute the quadrature weights for the point ``p.x[n]``.
+    :arg n: the index of the point within *p*.
     """
     raise NotImplementedError(
-        f"Cannot evaluate quadrature weights for method '{type(m).__name__}'"
+        f"Cannot evaluate quadrature weights for method '{type(m).__name__}' "
+        "('quadrature_weights' is not implemented)"
     )
 
 
 @singledispatch
 def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points, n: int) -> Scalar:
     r"""Evaluate the fractional derivative of *f* using method *m* at the point
-    *p.a* with the underlying grid.
+    *p.x[n]* with the underlying grid.
 
-    This function evaluates :math:`D^*[f](b)`, where :math:`f: [a, b] \to \mathbb{R}`,
-    i.e. at the end of the interval. This is in contract to :func:`diff`, which
-    evaluates the fractional derivative at all the points in the grid *p*.
+    This function evaluates :math:`D^*[f](x_n)`, where :math:`f: [a, b] \to \mathbb{R}`.
+    This is in contract to :func:`diff`, which evaluates the fractional derivative
+    at all the points in the grid *p*.
 
     .. note::
 
@@ -72,9 +81,27 @@ def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points, n: int) -> S
     :arg f: a simple function for which to evaluate the derivative.
     :arg p: an array of points at which to evaluate the derivative.
     """
-    raise NotImplementedError(
-        f"Cannot evaluate fractional derivative with method '{type(m).__name__}'"
+    try:
+        result = diff(m, f, p)
+    except NotImplementedError:
+        raise NotImplementedError(
+            "Cannot evaluate pointwise fractional derivative with method "
+            f"'{type(m).__name__}' ('diffs' is not implemented)"
+        ) from None
+
+    from warnings import warn
+
+    warn(
+        f"'diffs' is not implemented for '{type(m).__name__}' (aka '{m.name}'). "
+        "Falling back to 'diff', which is likely significantly slower! Use "
+        "'diff' directly if this is acceptable.",
+        stacklevel=2,
     )
+
+    if not 0 <= n <= p.size:
+        raise IndexError(f"Index 'n' out of range: 0 <= {n} < {p.size}")
+
+    return np.array(result[n])
 
 
 @singledispatch
@@ -84,10 +111,53 @@ def diff(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
     This function uses :func:`diffs` to evaluate the fractional derivative at
     all the points in *p*. In most cases it is a trivial wrapper.
 
+    .. note::
+
+        All methods are expected to implement this method, while
+        :func:`quadrature_weights` and :func:`diffs` are optional and not
+        supported by all methods.
+
     :arg m: method used to evaluate the derivative.
     :arg f: a simple function for which to evaluate the derivative.
     :arg p: an array of points at which to evaluate the derivative.
     """
     raise NotImplementedError(
-        f"Cannot evaluate fractional derivative with method '{type(m).__name__}'"
+        f"Cannot evaluate fractional derivative with method '{type(m).__name__}' "
+        "('diff' is not implemented)"
     )
+
+
+def quadrature_matrix(m: DerivativeMethod, p: Points, w00: float = 0.0) -> Array:
+    """Evaluate the quadrature matrix for a given method *m* at points *p*.
+
+    This requires that the method implements the :func:`quadrature_weights`. As
+    fractional operator are usually convolutional, this results in a lower
+    triangular matrix.
+
+    The value of the derivative at ``p.a`` is not defined. The value of the
+    matrix at ``W[0, 0]`` can be controlled using *w00*, which is set to 0 by
+    default. This default choice results in a singular operator and may not
+    always be desired.
+
+    Using this matrix operator, we can evaluate the derivative equivalently as
+
+    .. code:: python
+
+        mat = quadrature_matrix(m, p)
+
+        df_mat = mat @ f
+        df_fun = diff(m, f, p)
+        assert np.allclose(df_mat, df_fun)
+
+    :returns: a two-dimensional array of shape ``(n, n)``, where *n* is the
+        number of points in *p*.
+    """
+
+    n = p.size
+    W = np.zeros((n, n))
+    W[0, 0] = w00
+
+    for i in range(1, n):
+        W[i, : i + 1] = quadrature_weights(m, p, i + 1)
+
+    return W

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -67,6 +67,7 @@ def quadrature_weights(m: DerivativeMethod, p: Points, n: int) -> Array:
 
     :arg p: a grid on which to compute the quadrature weights for the point ``p.x[n]``.
     :arg n: the index of the point within *p*.
+    :returns: an array of quadrature weights of shape ``(n,)``.
     """
 
     raise NotImplementedError(
@@ -127,6 +128,8 @@ def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points, n: int) -> S
     :arg m: method used to evaluate the derivative.
     :arg f: a simple function for which to evaluate the derivative.
     :arg p: an array of points at which to evaluate the derivative.
+    :returns: a scalar representing the fractional derivative approximation at
+        the *nth* point in *p*.
     """
     raise NotImplementedError(
         "Cannot evaluate pointwise fractional derivative with method "
@@ -140,8 +143,10 @@ def diff(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
 
     By default, this function is implemented in terms of :func:`diffs`.
 
-    :arg f: a simple function for which to evaluate the derivative.
-    :arg p: an array of points at which to evaluate the derivative.
+    :arg f: an array or function for which to evaluate the derivative.
+    :arg p: a set points at which to evaluate the derivative.
+    :returns: an array of shape ``(n,)``, where *n* is the number of points in *p*,
+        that contains the evaluation of the fractional derivative at each point.
     """
     n = 1
 

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -87,23 +87,19 @@ def differentiation_matrix(m: DerivativeMethod, p: Points) -> Array:
     :returns: a two-dimensional array of shape ``(n, n)``, where *n* is the
         number of points in *p*.
     """
-    i = 1
+    n = p.size
+    W = np.zeros((n, n), dtype=p.dtype)
+    W[0, 0] = np.nan
 
     try:
-        w1 = quadrature_weights(m, p, i + 1)
+        for i in range(1, W.shape[0]):
+            w = quadrature_weights(m, p, i)
+            W[i, : w.size] = w
     except NotImplementedError:
         raise NotImplementedError(
             f"Cannot evaluate differentiation matrix for method '{type(m).__name__}' "
             "('differentiation_matrix' is not implemented)"
         ) from None
-
-    n = p.size
-    W = np.zeros((n, n), dtype=w1.dtype)
-    W[0, :1] = np.nan
-    W[0, :2] = w1
-
-    for i in range(2, W.shape[0]):
-        W[i, : i + 1] = quadrature_weights(m, p, i + 1)
 
     return W
 

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -19,7 +19,10 @@ class DerivativeMethod(ABC):
     @property
     def name(self) -> str:
         """An (non-unique) identifier for the differentiation method."""
-        return type(self).__name__.replace("Method", "")
+        cls = self.__class__
+        name = cls.__name__
+        module = cls.__module__.split(".")[-1]
+        return f"diff_{module}_{name}".lower()
 
     @property
     @abstractmethod
@@ -28,12 +31,55 @@ class DerivativeMethod(ABC):
 
 
 @singledispatch
+def quadrature_weights(m: DerivativeMethod, p: Array) -> Array:
+    r"""Evaluate the quadrature weights for the method *m* with points *p*.
+
+    In general, a fractional operator is an integral operator that we can write
+    as
+
+    .. math::
+
+        D^*[f](x_n) \approx \sum_{k = 0}^n w_{n, k} f_k
+
+    where :math:`w_{n, k}` is a row of the weight matrix that is computed by this
+    function. In some cases of interest, e.g. uniform, it is sufficient to
+    compute the :math:`w_{N, k}` row and perform the convolution by FFT.
+    """
+    raise NotImplementedError(
+        f"Cannot evaluate quadrature weights for method '{type(m).__name__}'"
+    )
+
+
+@singledispatch
+def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
+    r"""Evaluate the fractional derivative of *f* using method *m* at the point
+    *p.a* with the underlying grid.
+
+    This function evaluates :math:`D^*[f](b)`, where :math:`f: [a, b] \to \mathbb{R}`,
+    i.e. at the end of the interval. This is in contract to :func:`diff`, which
+    evaluates the fractional derivative at all the points in the grid *p*.
+
+    .. note::
+
+        The function *f* can be provided as a callable of as an array of values
+        evaluated on the grid *p*. However, not all methods support both variants
+        (e.g. if they require evaluating the function at additional points).
+
+    :arg m: method used to evaluate the derivative.
+    :arg f: a simple function for which to evaluate the derivative.
+    :arg p: an array of points at which to evaluate the derivative.
+    """
+    raise NotImplementedError(
+        f"Cannot evaluate fractional derivative with method '{type(m).__name__}'"
+    )
+
+
+@singledispatch
 def diff(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
     """Evaluate the fractional derivative of *f* at *p* using method *m*.
 
-    This is a low-level function that should be implemented by methods. For
-    a higher-level function see :func:`pycaputo.diff`. Note that this function
-    evaluates the derivative at all points in *p*, not just at *p[-1]*.
+    This function uses :func:`diffs` to evaluate the fractional derivative at
+    all the points in *p*. In most cases it is a trivial wrapper.
 
     :arg m: method used to evaluate the derivative.
     :arg f: a simple function for which to evaluate the derivative.

--- a/src/pycaputo/differentiation/base.py
+++ b/src/pycaputo/differentiation/base.py
@@ -9,7 +9,7 @@ from functools import singledispatch
 
 from pycaputo.derivatives import FractionalOperator
 from pycaputo.grid import Points
-from pycaputo.typing import Array, ArrayOrScalarFunction
+from pycaputo.typing import Array, ArrayOrScalarFunction, Scalar
 
 
 @dataclass(frozen=True)
@@ -31,7 +31,7 @@ class DerivativeMethod(ABC):
 
 
 @singledispatch
-def quadrature_weights(m: DerivativeMethod, p: Array) -> Array:
+def quadrature_weights(m: DerivativeMethod, p: Points, n: int) -> Array:
     r"""Evaluate the quadrature weights for the method *m* with points *p*.
 
     In general, a fractional operator is an integral operator that we can write
@@ -44,6 +44,9 @@ def quadrature_weights(m: DerivativeMethod, p: Array) -> Array:
     where :math:`w_{n, k}` is a row of the weight matrix that is computed by this
     function. In some cases of interest, e.g. uniform, it is sufficient to
     compute the :math:`w_{N, k}` row and perform the convolution by FFT.
+
+    :arg p: a grid on which to compute the quadrature weights at the point
+        ``p.x[n]``.
     """
     raise NotImplementedError(
         f"Cannot evaluate quadrature weights for method '{type(m).__name__}'"
@@ -51,7 +54,7 @@ def quadrature_weights(m: DerivativeMethod, p: Array) -> Array:
 
 
 @singledispatch
-def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points) -> Array:
+def diffs(m: DerivativeMethod, f: ArrayOrScalarFunction, p: Points, n: int) -> Scalar:
     r"""Evaluate the fractional derivative of *f* using method *m* at the point
     *p.a* with the underlying grid.
 

--- a/src/pycaputo/differentiation/caputo.py
+++ b/src/pycaputo/differentiation/caputo.py
@@ -88,11 +88,11 @@ def _caputo_piecewise_constant_integral(p: Points, n: int, alpha: float) -> Arra
 
 @quadrature_weights.register(L1)
 def _quadrature_weights_caputo_l1(m: L1, p: Points, n: int) -> Array:
-    if n < 0:
-        n = p.size + n
-
     if not 0 <= n <= p.size:
         raise IndexError(f"Index 'n' out of range: 0 <= {n} < {p.size}")
+
+    if n == 0:
+        return np.array([])
 
     w = np.empty(n, dtype=p.x.dtype)
     w[n - 1] = 0.0

--- a/src/pycaputo/differentiation/caputo.py
+++ b/src/pycaputo/differentiation/caputo.py
@@ -77,7 +77,7 @@ def _caputo_piecewise_constant_integral(p: Points, n: int, alpha: float) -> Arra
     x, dx = p.x[:n], p.dx[: n - 1]
     xn = x[-1]
 
-    return (
+    return np.array(
         ((xn - x[:-1]) ** (1 - alpha) - (xn - x[1:]) ** (1 - alpha))
         / dx
         / math.gamma(2 - alpha)
@@ -113,7 +113,7 @@ def _diffs_caputo_l1(m: L1, f: ArrayOrScalarFunction, p: Points, n: int) -> Scal
         return np.array([np.nan])
 
     w = quadrature_weights(m, p, n + 1)
-    fx = f(p.x[: n + 1]) if callable(f) else f[:n + 1]
+    fx = f(p.x[: n + 1]) if callable(f) else f[: n + 1]
 
     return np.sum(w * fx)  # type: ignore[no-any-return]
 
@@ -123,7 +123,7 @@ def _diff_caputo_l1(m: L1, f: ArrayOrScalarFunction, p: Points) -> Array:
     fx = f(p.x) if callable(f) else f
     if fx.shape[0] != p.size:
         raise ValueError(
-            f"Shape of 'f' does match points: got {f.shape} expected {p.shape}"
+            f"Shape of 'f' does match points: got {fx.shape} expected {p.shape}"
         )
 
     df = np.empty_like(fx)
@@ -254,7 +254,7 @@ def _quadrature_weights_caputo_l2(m: L2, p: Points, n: int) -> Array:
     if not 0 <= n <= p.size:
         raise IndexError(f"Index 'n' out of range: 0 <= {n} < {p.size}")
 
-    dx = p.dx[:n - 1]
+    dx = p.dx[: n - 1]
     dxm = (dx[1:] + dx[:-1]) / 2.0
 
     # get finite difference coefficients for center stencil
@@ -269,7 +269,7 @@ def _quadrature_weights_caputo_l2(m: L2, p: Points, n: int) -> Array:
 
     w = np.empty_like(p.x[:n])
     # center stencil
-    w[2:n - 1] = a * wi[2:] - (a + b) * w[1:-1] + b * w[:-2]
+    w[2 : n - 1] = a * wi[2:] - (a + b) * w[1:-1] + b * w[:-2]
     # add left boundary stencil
     w[0] = a_l + a[1] * wi[1]
     w[1] = b_l + a[2] * wi[2] - (a[1] + b[1]) * wi[1]
@@ -297,7 +297,7 @@ def _diffs_caputo_l2(m: L2, f: ArrayOrScalarFunction, p: Points, n: int) -> Arra
         return np.array([np.nan])
 
     w = quadrature_weights(m, p, n + 1)
-    fx = f(p.x[: n + 1]) if callable(f) else f[:n + 1]
+    fx = f(p.x[: n + 1]) if callable(f) else f[: n + 1]
 
     return np.sum(w * fx)  # type: ignore[no-any-return]
 
@@ -307,7 +307,7 @@ def _diff_caputo_l2(m: L2, f: ArrayOrScalarFunction, p: Points) -> Array:
     fx = f(p.x) if callable(f) else f
     if fx.shape[0] != p.size:
         raise ValueError(
-            f"Shape of 'f' does match points: got {f.shape} expected {p.shape}"
+            f"Shape of 'f' does match points: got {fx.shape} expected {p.shape}"
         )
 
     df = np.empty_like(fx)
@@ -318,6 +318,8 @@ def _diff_caputo_l2(m: L2, f: ArrayOrScalarFunction, p: Points) -> Array:
     for n in range(1, df.size):
         w = quadrature_weights(m, p, n + 1)
         df[n] = np.sum(w * fx[: n + 1])
+
+    return df
 
 
 def _weights_l2(alpha: float, i: int | Array, k: int | Array) -> Array:

--- a/src/pycaputo/differentiation/caputo.py
+++ b/src/pycaputo/differentiation/caputo.py
@@ -161,7 +161,7 @@ class ModifiedL1(CaputoMethod):
     This method is defined in Section 4.1.1 (III) from [Li2020]_. Note that this
     method evaluates the fractional derivative at the midpoints
     :math:`(x_i + x_{i - 1}) / 2` for any given input grid except
-    :class:`~pycaputo.grids.MidPoints`.
+    :class:`~pycaputo.grid.MidPoints`.
 
     As noted in [Li2020]_, this method has the same order of convergence as the
     standard L1 method. However the weights can be used to construct a
@@ -186,8 +186,6 @@ def _quadrature_weights_caputo_modified_l1(m: ModifiedL1, p: Points, n: int) -> 
         p = make_midpoints_from(p)
         w = quadrature_weights.dispatch(L1)(m, p, n)
 
-        # FIXME: not clear if this does anything? Might be the same as just
-        # doing L1 on the original grid..
         wp = np.empty((n + 1,), dtype=w.dtype)
         wp[0] = w[0] / 2.0
         wp[-1] = w[-1] / 2.0
@@ -238,7 +236,7 @@ class L2(CaputoMethod):
 
     .. note::
 
-        Unlike the method from [Li2020_], we do not assume knowledge of points
+        Unlike the method from [Li2020]_, we do not assume knowledge of points
         outside of the domain. Instead a biased stencil is used at the boundary.
     """
 
@@ -430,13 +428,14 @@ class L2F(CaputoMethod):
     r"""Implements the L2 method for the Caputo fractional derivative
     of order :math:`\alpha \in (1, 2)`.
 
-    This is similar to :class:`L2`, but it assumes that the function *f* can
-    be evaluated at :math:`f(x_{-1})` outside of the domain :math:`[a, b]`.
+    This is similar to :class:`L2`, but it assumes that *f* is a callable that can
+    be evaluated at :math:`f(x_{-1})`, i.e. outside of the domain :math:`[a, b]`.
     For symmetry, we set :math:`x_{-1} = a - \Delta x_0`. This allows using
     the same centered stencil for all the points in the domain.
 
     This method mainly exists for comparison with the literature, as [Li2020]_
-    also uses the value outside of the interval.
+    also uses the value outside of the interval. Note that this is not always
+    possible, e.g. for :math:`\sqrt{x}` on :math:`[0, 1]`.
     """
 
 
@@ -536,7 +535,7 @@ class LXD(CaputoMethod):
     This method is equivalent to :class:`L1` (or :class:`L2` method), but
     evaluation requires explicit knowledge of the required derivative, i.e. the
     *f* function must be a callable satisfying
-    :class:`~pycaputo.tuping.DifferentiableScalarFunction`. With explicit
+    :class:`~pycaputo.typing.DifferentiableScalarFunction`. With explicit
     knowledge of the derivative, we can evaluate any fractional order.
 
     The derivatives are always evaluated at the midpoint of each interval.
@@ -621,6 +620,7 @@ def _diff_caputo_lxd(m: LXD, f: ArrayOrScalarFunction, p: Points) -> Array:
 
 
 # }}}
+
 
 # {{{ SpectralJacobi
 

--- a/src/pycaputo/differentiation/caputo.py
+++ b/src/pycaputo/differentiation/caputo.py
@@ -547,23 +547,22 @@ def _diff_caputo_l2f(m: L2F, f: ArrayOrScalarFunction, p: Points) -> Array:
     dx = p.dx
     dxm = p.dxm
     alpha = m.alpha
-
     fx = f(p.x)
 
     # estimate second-order derivative
     # NOTE: this is faster than using the quadrature weights
     ddfx = np.empty(p.size - 1, dtype=fx.dtype)
 
-    cm = 1.0 / (dx[:-1] * dxm)
-    cp = 1.0 / (dx[1:] * dxm)
+    cm = 1.0 / dx[:-1]
+    cp = 1.0 / dx[1:]
 
     if m.side == Side.Left:
         fa = f(p.a - dx[0])
-        ddfx[1:] = cm * fx[:-2] - (cm + cp) * fx[1:-1] + cp * fx[2:]
+        ddfx[1:] = (cm * fx[:-2] - (cm + cp) * fx[1:-1] + cp * fx[2:]) / dxm
         ddfx[0] = (fx[1] - 2.0 * fx[0] + fa) / dx[0] ** 2
     else:
         fb = f(p.b + dx[-1])
-        ddfx[:-1] = cm * fx[:-2] - (cm + cp) * fx[1:-1] + cp * fx[2:]
+        ddfx[:-1] = (cm * fx[:-2] - (cm + cp) * fx[1:-1] + cp * fx[2:]) / dxm
         ddfx[-1] = (fx[-2] - 2.0 * fx[-1] + fb) / dx[-1] ** 2
 
     # FIXME: in the uniform case, we can also do an FFT, but we need different

--- a/src/pycaputo/differentiation/riemann_liouville.py
+++ b/src/pycaputo/differentiation/riemann_liouville.py
@@ -7,13 +7,15 @@ import math
 from dataclasses import dataclass
 from functools import cached_property
 
+import numpy as np
+
 from pycaputo.derivatives import RiemannLiouvilleDerivative, Side
 from pycaputo.grid import Points
 from pycaputo.logging import get_logger
-from pycaputo.typing import Array, ArrayOrScalarFunction
+from pycaputo.typing import Array, ArrayOrScalarFunction, Scalar
 
 from . import caputo
-from .base import DerivativeMethod, diff
+from .base import DerivativeMethod, diff, diffs, quadrature_weights
 
 logger = get_logger(__name__)
 
@@ -96,6 +98,93 @@ class L2C(RiemannLiouvilleFromCaputoMethod):
         return caputo.L2C(self.alpha)
 
 
+def _rl_d1_boundary_coefficients(x: Array) -> Array:
+    # NOTE: this is a 3rd order approximation of the derivative at f(a)
+    # that works on non-uniform grids too (derived by Mathematica)
+
+    x0, x1, x2, x3 = x[:4]
+    c0 = 1.0 / (x0 - x1) + 1.0 / (x0 - x2) + 1.0 / (x0 - x3)
+    c1 = -(x0 - x2) * (x0 - x3) / ((x0 - x1) * (x1 - x2) * (x1 - x3))
+    c2 = -(x0 - x1) * (x0 - x3) / ((x0 - x2) * (x2 - x1) * (x2 - x3))
+    c3 = -(x0 - x1) * (x0 - x2) / ((x0 - x3) * (x3 - x1) * (x3 - x2))
+
+    return np.array([c0, c1, c2, c3])
+
+
+def _rl_correction_weights(
+    m: RiemannLiouvilleFromCaputoMethod,
+    x: Array,
+    n: int,
+) -> Array:
+    xn = x[n]
+    alpha = m.alpha
+    w0 = 1.0 / (xn - x[0]) ** alpha / math.gamma(1 - alpha)
+
+    if 0.0 < alpha < 1.0:
+        w = np.array([w0], dtype=x.dtype)
+    elif 1.0 < alpha < 2.0:
+        w = (
+            _rl_d1_boundary_coefficients(x)
+            / (xn - x[0]) ** (alpha - 1)
+            / math.gamma(2 - alpha)
+        )
+        w[0] += w0
+    else:
+        raise NotImplementedError
+
+    return w
+
+
+def _rl_correction(m: RiemannLiouvilleFromCaputoMethod, x: Array, fx: Array) -> Array:
+    alpha = m.alpha
+    df = fx[0] / (x[1:] - x[0]) ** alpha / math.gamma(1 - alpha)
+
+    if 0.0 < alpha <= 1.0:
+        # NOTE: handled above
+        pass
+    elif 1.0 < alpha <= 2.0:
+        dfx = _rl_d1_boundary_coefficients(x) @ fx[:4]
+        df += dfx / (x[1:] - x[0]) ** (alpha - 1) / math.gamma(2 - alpha)
+    else:
+        raise NotImplementedError(f"Unsupported derivative order: {alpha}")
+
+    return np.array(df)
+
+
+@quadrature_weights.register(L1)
+@quadrature_weights.register(L2)
+@quadrature_weights.register(L2C)
+def _quadrature_weights_rl_from_caputo(
+    m: RiemannLiouvilleFromCaputoMethod,
+    p: Points,
+    n: int,
+) -> Array:
+    w = quadrature_weights(m.base, p, n)
+
+    wc = _rl_correction_weights(m, p.x, n)
+    w[: wc.size] += wc
+
+    return w
+
+
+@diffs.register(L1)
+@diffs.register(L2)
+@diffs.register(L2C)
+def _diffs_rl_from_caputo(
+    m: RiemannLiouvilleFromCaputoMethod,
+    f: ArrayOrScalarFunction,
+    p: Points,
+    n: int,
+) -> Scalar:
+    x = p.x
+    fx = f(x[: n + 1]) if callable(f) else f[: n + 1]
+
+    df = diffs(m.base, fx, p, n)
+
+    wc = _rl_correction_weights(m, p.x, n)
+    return df + wc @ fx[: wc.size]  # type: ignore[no-any-return]
+
+
 @diff.register(L1)
 @diff.register(L2)
 @diff.register(L2C)
@@ -104,33 +193,11 @@ def _diff_rl_from_caputo(
     f: ArrayOrScalarFunction,
     p: Points,
 ) -> Array:
-    alpha = m.alpha
     x = p.x
     fx = f(x) if callable(f) else f
 
     df = diff(m.base, fx, p)
-    df[1:] += fx[0] / (x[1:] - x[0]) ** alpha / math.gamma(1 - alpha)
-
-    if 0.0 < alpha <= 1.0:
-        # NOTE: handled above
-        pass
-    elif 1.0 < alpha <= 2.0:
-        # NOTE: this is a 3rd order approximation of the derivative at f(a)
-        # that works on non-uniform grids too (derived by Mathematica)
-        dfx = (
-            # fmt: off
-            (fx[0] - fx[1]) / (x[0] - x[1])
-            + (fx[0] - fx[2]) / (x[0] - x[2])
-            + (fx[0] - fx[3]) / (x[0] - x[3])
-            - (fx[1] - fx[2]) / (x[1] - x[2])
-            - (fx[1] - fx[3]) * (x[0] - x[2]) / ((x[1] - x[2]) * (x[1] - x[3]))
-            + (fx[2] - fx[3]) * (x[0] - x[1]) / ((x[1] - x[2]) * (x[2] - x[3]))
-            # fmt: on
-        )
-
-        df[1:] += dfx / (x[1:] - x[0]) ** (alpha - 1) / math.gamma(2 - alpha)
-    else:
-        raise NotImplementedError(f"Unsupported derivative order: {alpha}")
+    df[1:] += _rl_correction(m, p.x, fx)
 
     return df
 

--- a/src/pycaputo/finite_difference.py
+++ b/src/pycaputo/finite_difference.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
+# q SPDX-FileCopyrightText: 2023 Alexandru Fikl <alexfikl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/pycaputo/fode/caputo.py
+++ b/src/pycaputo/fode/caputo.py
@@ -39,6 +39,8 @@ def _truncation_error(
 ) -> Array:
     from pycaputo.controller import JannelliIntegralController
 
+    # FIXME: this should not be our job: either let the controller or the method
+    # figure out how to compute the truncation error estimates.
     assert t > tprev
     if isinstance(c, JannelliIntegralController):
         trunc = np.array(

--- a/src/pycaputo/grid.py
+++ b/src/pycaputo/grid.py
@@ -148,23 +148,35 @@ def make_uniform_points(n: int, a: float = 0.0, b: float = 1.0) -> UniformPoints
 
 
 @dataclass(frozen=True)
-class UniformMidpoints(Points):
-    """A set of points on :math:`[a, b]` formed from midpoints of a uniform grid.
+class MidPoints(Points):
+    """A set of points on :math:`[a, b]` formed from midpoints of another grid.
 
     This set of points consists of :math:`x_0 = a` and :math:`x_j` are the
-    midpoints of the uniform grid :class:`UniformPoints`
+    midpoints of another grid.
     """
 
 
-def make_uniform_midpoints(n: int, a: float = 0.0, b: float = 1.0) -> UniformMidpoints:
-    """Construct a :class:`UniformMidpoints` on :math:`[a, b]`.
+def make_uniform_midpoints(n: int, a: float = 0.0, b: float = 1.0) -> MidPoints:
+    """Construct a :class:`MidPoints` on :math:`[a, b]`.
 
     :arg n: number of points in :math:`[a, b]`.
     """
     x = np.linspace(a, b, n)
     x[1:] = (x[1:] + x[:-1]) / 2
 
-    return UniformMidpoints(a=a, b=b, x=x)
+    return MidPoints(a=a, b=b, x=x)
+
+
+def make_midpoints_from(p: Points) -> MidPoints:
+    """Construct a grid of midpoints from a given set of points *p*.
+
+    The new grid will contain the point :math:`x_0` and the midpoints of *p*.
+    """
+    x = np.empty_like(p.x)
+    x[0] = p.x[0]
+    x[1:] = p.xm
+
+    return MidPoints(a=p.a, b=p.b, x=x)
 
 
 # }}}

--- a/src/pycaputo/grid.py
+++ b/src/pycaputo/grid.py
@@ -56,6 +56,11 @@ class Points:
         """Array of midpoints."""
         return np.array(self.x[1:] + self.x[:-1]) / 2
 
+    @cached_property
+    def dxm(self) -> Array:
+        """Distance between midpoints."""
+        return np.diff(self.xm)
+
     def translate(self, a: float, b: float) -> Points:
         """Linearly translate the set of points to the new interval :math:`[a, b]`."""
         # translate from [a', b'] to [0, 1] to [a, b]

--- a/src/pycaputo/lagrange.py
+++ b/src/pycaputo/lagrange.py
@@ -76,7 +76,8 @@ def lagrange_riemann_liouville_integral(
 
     .. math::
 
-        I^\alpha[\phi_{kj}](x_n) = \frac{1}{\Gamma(\alpha)} \int_{0}^{x_n}
+        I^\alpha[\phi_{kj}](x_n) =
+            \frac{1}{\Gamma(\alpha)} \int_{0}^{x_n}
             (x_n - s)^{\alpha - 1} \phi_{kj}(s) \,\mathrm{d}s.
 
     As the polynomials are zero except in the domain of definition, this simplifies
@@ -133,7 +134,7 @@ def lagrange_caputo_derivative(
 
     .. math::
 
-        D^{q, \alpha}_{nk} \triangleq
+        L^{q, \alpha}_{nk} \triangleq
             \frac{1}{\Gamma(m - \alpha)}
             \int_{x_k}^{x_{k + 1}} (x_n - s)^{m - \alpha - 1}
             \frac{\mathrm{d}^m}{\mathrm{d} s^m}

--- a/src/pycaputo/quadrature/riemann_liouville.py
+++ b/src/pycaputo/quadrature/riemann_liouville.py
@@ -271,14 +271,20 @@ def _quad_rl_cubic_hermite(
 ) -> Array:
     from pycaputo.grid import UniformPoints
 
-    if not isinstance(f, DifferentiableScalarFunction):
-        raise TypeError(f"Input 'f' needs to be a callable: {type(f).__name__}")
-
     if not isinstance(p, UniformPoints):
         raise TypeError(f"Only uniform points are supported: {type(p).__name__}")
 
-    fx = f(p.x, d=0)
-    fp = f(p.x, d=1)
+    # FIXME: isinstance(f, DifferentiableScalarFunction) does not work?
+    assert isinstance(f, DifferentiableScalarFunction)
+
+    try:
+        fx = f(p.x, d=0)
+        fp = f(p.x, d=1)
+    except TypeError as exc:
+        raise TypeError(
+            f"{type(m).__name__!r} requires a 'DifferentiableScalarFunction': "
+            f"f is a {type(f).__name__!r}"
+        ) from exc
 
     alpha = -m.alpha
     h = p.dx[0]

--- a/src/pycaputo/typing.py
+++ b/src/pycaputo/typing.py
@@ -26,16 +26,21 @@ else:
 
 # {{{ TypeVars
 
+# NOTE: sphinx doesn't seem to render this correctly at the moment, so it's
+# written explicitly in `misc_others.rst`
 P = ParamSpec("P")
 
 T = TypeVar("T")
 """A generic invariant :class:`typing.TypeVar`."""
 R = TypeVar("R")
 """A generic invariant :class:`typing.TypeVar`."""
+
 PathLike = Union[pathlib.Path, str]
 """A union of types supported as paths."""
 
+
 # }}}
+
 
 # {{{ numpy
 
@@ -51,6 +56,7 @@ else:
 
 
 # }}}
+
 
 # {{{ dataclass
 
@@ -68,6 +74,7 @@ class DataclassInstance(Protocol):
 # {{{ callable protocols
 
 
+@runtime_checkable
 class ScalarFunction(Protocol):
     """A generic callable that can be evaluated at :math:`x`.
 
@@ -80,6 +87,26 @@ class ScalarFunction(Protocol):
         """
 
 
+@runtime_checkable
+class DifferentiableScalarFunction(Protocol):
+    """A :class:`ScalarFunction` that can also compute its integer order derivatives.
+
+    .. automethod:: __call__
+    """
+
+    def __call__(self, x: Array, /, d: int = 0) -> Array:
+        """Evaluate the function or any of its derivatives.
+
+        :arg x: a scalar or array at which to evaluate the function.
+        :arg d: order of the derivative.
+        """
+
+
+ArrayOrScalarFunction = Union[Array, ScalarFunction, DifferentiableScalarFunction]
+"""A union of scalar functions."""
+
+
+@runtime_checkable
 class StateFunction(Protocol):
     r"""A generic callable for right-hand side functions
     :math:`\mathbf{f}(t, \mathbf{y})`.
@@ -94,6 +121,7 @@ class StateFunction(Protocol):
         """
 
 
+@runtime_checkable
 class ScalarStateFunction(Protocol):
     """A generic callable similar to :class:`StateFunction` that returns a
     scalar.
@@ -108,27 +136,8 @@ class ScalarStateFunction(Protocol):
         """
 
 
-@runtime_checkable
-class DifferentiableScalarFunction(Protocol):
-    """A :class:`ScalarFunction` that can also compute its integer order derivatives.
-
-    By default no derivatives are implemented, so subclasses can handle any such
-    cases.
-    """
-
-    def __call__(self, x: Array, /, d: int = 0) -> Array:
-        """Evaluate the function or any of its derivatives.
-
-        :arg x: a scalar or array at which to evaluate the function.
-        :arg d: order of the derivative.
-        """
-
-
 StateFunctionT = TypeVar("StateFunctionT", bound=StateFunction)
 """An invariant :class:`~typing.TypeVar` bound to :class:`StateFunction`."""
-
-ArrayOrScalarFunction = Union[Array, ScalarFunction, DifferentiableScalarFunction]
-"""A union of scalar functions."""
 
 
 # }}}

--- a/tests/test_diff_caputo.py
+++ b/tests/test_diff_caputo.py
@@ -198,7 +198,7 @@ def test_caputo_spectral(
     from pycaputo.grid import make_jacobi_gauss_lobatto_points
     from pycaputo.utils import EOCRecorder, savefig
 
-    meth = caputo.SpectralJacobi(alpha=alpha)
+    meth = caputo.Jacobi(alpha=alpha)
     eoc = EOCRecorder()
 
     if visualize:

--- a/tests/test_diff_caputo.py
+++ b/tests/test_diff_caputo.py
@@ -63,6 +63,7 @@ def df_test(x: Array, *, alpha: float, mu: float = 3.5) -> Array:
     [
         ("L1", "stretch"),
         ("L1", "uniform"),
+        ("L1D", "uniform"),
         ("L2", "uniform"),
         ("L2C", "uniform"),
         ("ModifiedL1", "midpoints"),
@@ -92,6 +93,9 @@ def test_caputo_lmethods(
     meth: caputo.CaputoMethod
     if name == "L1":
         meth = caputo.L1(alpha=alpha)
+        order = 2.0 - alpha
+    elif name == "L1D":
+        meth = caputo.L1D(alpha=alpha)
         order = 2.0 - alpha
     elif name == "ModifiedL1":
         meth = caputo.ModifiedL1(alpha=alpha)
@@ -474,7 +478,7 @@ def test_caputo_vs_differint(
     else:
         # NOTE: we use slightly different boundary handling for the L2 methods
         # so these get larger errors compared to differint
-        assert error_vs_di < 1.0e-2
+        assert error_vs_di < 1.1e-2
 
 
 # }}}

--- a/tests/test_diff_caputo.py
+++ b/tests/test_diff_caputo.py
@@ -29,6 +29,8 @@ def f_test(x: Array, d: int = 0, *, mu: float = 3.5) -> Array:
         return (0.5 - x) ** mu
     elif d == 1:
         return -mu * (0.5 - x) ** (mu - 1)
+    elif d == 2:
+        return mu * (mu - 1) * (0.5 - x) ** (mu - 2)
     else:
         raise NotImplementedError
 
@@ -66,6 +68,8 @@ def df_test(x: Array, *, alpha: float, mu: float = 3.5) -> Array:
         ("L1D", "uniform"),
         ("L2", "uniform"),
         ("L2C", "uniform"),
+        ("L2D", "uniform"),
+        ("L2F", "uniform"),
         ("ModifiedL1", "midpoints"),
         ("ModifiedL1", "stretch"),
     ],
@@ -85,7 +89,7 @@ def test_caputo_lmethods(
 
     from pycaputo.grid import make_points_from_name
 
-    if name in {"L2", "L2C"}:
+    if name in {"L2", "L2C", "L2D", "L2F"}:
         alpha += 1
 
     from pycaputo.utils import EOCRecorder, savefig, stringify_eoc
@@ -95,7 +99,7 @@ def test_caputo_lmethods(
         meth = caputo.L1(alpha=alpha)
         order = 2.0 - alpha
     elif name == "L1D":
-        meth = caputo.L1D(alpha=alpha)
+        meth = caputo.LXD(alpha=alpha)
         order = 2.0 - alpha
     elif name == "ModifiedL1":
         meth = caputo.ModifiedL1(alpha=alpha)
@@ -106,6 +110,12 @@ def test_caputo_lmethods(
         order = 1.0
     elif name == "L2C":
         meth = caputo.L2C(alpha=alpha)
+        order = 3.0 - alpha
+    elif name == "L2F":
+        meth = caputo.L2F(alpha=alpha)
+        order = 1.0
+    elif name == "L2D":
+        meth = caputo.LXD(alpha=alpha)
         order = 3.0 - alpha
     else:
         raise ValueError(f"Unsupported method: '{name}'")
@@ -127,6 +137,7 @@ def test_caputo_lmethods(
 
         df_num = diff(meth, f_test, p)
         df_ref = df_test(p.x, alpha=alpha)
+        print(df_num[:10] - df_ref[:10])
 
         h = np.max(p.dx)
         e = la.norm(df_num[1:] - df_ref[1:]) / la.norm(df_ref[1:])

--- a/tests/test_diff_caputo.py
+++ b/tests/test_diff_caputo.py
@@ -108,7 +108,9 @@ def make_method_from_name(
         meth = caputo.L2C(alpha=alpha)
         order = 3.0 - alpha
     elif name == "L2F":
-        meth = caputo.L2F(alpha=alpha)
+        from pycaputo.derivatives import Side
+
+        meth = caputo.L2F(alpha=alpha, side=Side.Left)
         order = 1.0
     elif name == "L2D":
         meth = caputo.LXD(alpha=alpha)
@@ -621,7 +623,7 @@ def test_caputo_consistency(
 
         error = la.norm(df_from_diffs - df_ref[n]) / la.norm(df_ref[n])
         logger.info("   error %.12e", error)
-        assert error < 1.0e-15
+        assert error < 6.0e-12
 
 
 # }}}

--- a/tests/test_diff_caputo.py
+++ b/tests/test_diff_caputo.py
@@ -66,6 +66,7 @@ def df_test(x: Array, *, alpha: float, mu: float = 3.5) -> Array:
         ("L2", "uniform"),
         ("L2C", "uniform"),
         ("ModifiedL1", "midpoints"),
+        ("ModifiedL1", "stretch"),
     ],
 )
 @pytest.mark.parametrize("alpha", [0.1, 0.25, 0.5, 0.75, 0.9])
@@ -115,6 +116,11 @@ def test_caputo_lmethods(
 
     for n in [16, 32, 64, 128, 256, 512, 768, 1024]:
         p = make_points_from_name(grid_type, n, a=0.0, b=0.5)
+        if name == "ModifiedL1" and grid_type != "midpoints":
+            from pycaputo.grid import make_midpoints_from
+
+            p = make_midpoints_from(p)
+
         df_num = diff(meth, f_test, p)
         df_ref = df_test(p.x, alpha=alpha)
 


### PR DESCRIPTION
See discussion in #55. Methods that need updating

#### Caputo

* [x] L1
* [x] ModifiedL1
* [x] L2
* [ ] L2C
* [ ] SpectralJacobi
	* This method evaluates the derivative on the whole grid. 
* [ ] YuanAgrawal
	- These diffusive methods do not have weights in the sense from #55. However, we can still implement evaluating at a given point. 
* [ ] Diethelm
* [ ] BirkSong

#### Riemann-Liouville

Should just work once Caputo methods are updated.

#### Grünwald-Letnikov

* [ ] GrunwaldLetnikov
* [ ] ShiftedGrunwaldLetnikov
* [ ] TianZhouDeng2
* [ ] TianZhouDeng3

#### Gradient

Reimplement gradient based on `diffs` method. Methods that don't support it can take a long hard look at themselves.

Fixes #55.