### PR TITLE
Rework time stepping

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,7 +31,7 @@ Breaking Changes
   a tuple of :class:`~pycaputo.derivatives.FractionalOperator` instances, not
   just derivative orders. This requires changing ``derivatives=(alpha, ...)``
   to ``ds=(CaputoDerivative(alpha), ...)``.
-* Remove the ``gamma1p``, ``gamma2p``, ``gamma2m`` functions from
+* Removed the ``gamma1p``, ``gamma2p``, ``gamma2m`` functions from
   :mod:`pycaputo.stepping`. Maybe the Caputo classes will cache them in the
   future.
 * All :class:`~pycaputo.stepping.FractionalDifferentialEquationMethod` need to

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -215,7 +215,7 @@ Features
 * Store an :class:`~numpy.ndarray` for the orders so that they are not recomputed
   at each time step in :class:`~pycaputo.stepping.FractionalDifferentialEquationMethod`.
   Several functions using :func:`~pycaputo.utils.cached_on_first_arg`, e.g.
-  :func:`~pycaputo.stepping.gamma1p` are also cached.
+  ``gamma1p`` are also cached.
 * Rework the hierarchy for the product integration methods and update their
   names. They are now available in :mod:`pycaputo.fode.caputo` only and called
   directly ``ForwardEuler`` (before it was ``CaputoForwardEulerMethod``).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,9 @@ Features
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+* Remove the ``gamma1p``, ``gamma2p``, ``gamma2m`` functions from
+  :mod:`pycaputo.stepping`. Maybe the Caputo classes will cache them in the
+  future.
 * All :class:`~pycaputo.stepping.FractionalDifferentialEquationMethod` need to
   also define :meth:`~pycaputo.stepping.FractionalDifferentialEquationMethod.make_default_history`.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,10 @@ Features
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+* :class:`~pycaputo.stepping.FractionalDifferentialEquationMethod` now takes
+  a tuple of :class:`~pycaputo.derivatives.FractionalOperator` instances, not
+  just derivative orders. This requires changing ``derivatives=(alpha, ...)``
+  to ``ds=(CaputoDerivative(alpha), ...)``.
 * Remove the ``gamma1p``, ``gamma2p``, ``gamma2m`` functions from
   :mod:`pycaputo.stepping`. Maybe the Caputo classes will cache them in the
   future.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ extensions = [
 ]
 
 # extension for source files
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 # name of the main (master) document
 master_doc = "index"
 # min sphinx version

--- a/examples/gallery/adex.py
+++ b/examples/gallery/adex.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import ad_ex
 
 # setup system (parameters from [Naud2008])
@@ -34,7 +35,7 @@ print(control)
 
 # setup stepper
 stepper = ad_ex.CaputoAdExIntegrateFireL1Model(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     y0=(y0,),
     source=model,

--- a/examples/gallery/arneodo.py
+++ b/examples/gallery/arneodo.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Arneodo
 
 # setup system (parameters from Figure 5.43 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/brusselator.py
+++ b/examples/gallery/brusselator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Brusselator
 
 # setup system
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/chen.py
+++ b/examples/gallery/chen.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Chen
 
 # setup system (parameters from Figure 5.33 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/chua.py
+++ b/examples/gallery/chua.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Chua
 
 # setup system (parameters from Figure 5.6 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/cnn.py
+++ b/examples/gallery/cnn.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import CellularNeuralNetwork3
 
 # setup system (parameters from Figure 5.58 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/duffing.py
+++ b/examples/gallery/duffing.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Duffing
 
 # setup system (parameters from Figure 5.29 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/fitzhugh-nagumo.py
+++ b/examples/gallery/fitzhugh-nagumo.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplots
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import FitzHughNagumo
 
 # setup system (parameters from Figure 4d from [Brandibur2018])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.L1(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     source_jac=func.source_jac,

--- a/examples/gallery/fitzhugh-rinzel.py
+++ b/examples/gallery/fitzhugh-rinzel.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import FitzHughRinzel, FitzHughRinzelParameter
 
 # setup system (parameters from Figure 3g from [Mondal2019])
@@ -29,7 +30,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.L1(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     source_jac=func.source_jac,

--- a/examples/gallery/genesio-tesi.py
+++ b/examples/gallery/genesio-tesi.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import GenesioTesi
 
 # setup system (parameters from Figure 5.40 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/hindmarsh-rose2.py
+++ b/examples/gallery/hindmarsh-rose2.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplots
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import HindmarshRose2
 
 # setup system (parameters from Figure 3b from [Kaslik2017])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/hindmarsh-rose3.py
+++ b/examples/gallery/hindmarsh-rose3.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplots
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import HindmarshRose3
 
 # parameters from Figure 5a from [Kaslik2017]
@@ -36,7 +37,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/hindmarsh-rose4.py
+++ b/examples/gallery/hindmarsh-rose4.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplots
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import HindmarshRose4
 
 # setup system (parameters from Figure 1 from [Giresse2019])
@@ -43,7 +44,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/hodgkin-huxley.py
+++ b/examples/gallery/hodgkin-huxley.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplots
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import HodgkinHuxley, StandardHodgkinHuxleyParameter
 
 # setup system (parameters from Figure 4 from [Nagy2014])
@@ -31,7 +32,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/labyrinth.py
+++ b/examples/gallery/labyrinth.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Labyrinth
 
 # setup system
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/lif.py
+++ b/examples/gallery/lif.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import lif
 from pycaputo.typing import Array
 
@@ -48,7 +49,7 @@ print(control)
 
 # setup stepper
 stepper = lif.CaputoLeakyIntegrateFireL1Method(
-    derivative_order=(alpha,),
+    ds=(D(alpha),),
     control=control,
     y0=(y0,),
     source=model,

--- a/examples/gallery/liu.py
+++ b/examples/gallery/liu.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Liu
 
 # setup system (parameters from Figure 5.37 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/lorenz.py
+++ b/examples/gallery/lorenz.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Lorenz
 
 # setup system (parameters from Figure 5.32 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/lorenz84.py
+++ b/examples/gallery/lorenz84.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Lorenz84
 
 # setup system (parameters from Figure 2a in [Premakumari2022])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/lotka-volterra.py
+++ b/examples/gallery/lotka-volterra.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import LotkaVolterra2
 
 # setup system (parameters from Figure 6 from [Ahmed2007])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/lotka-volterra3.py
+++ b/examples/gallery/lotka-volterra3.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import LotkaVolterra3
 
 # setup system (parameters from Figure 5.53 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/lu.py
+++ b/examples/gallery/lu.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Lu
 
 # setup system (parameters from Figure 5.35 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/ma-chen.py
+++ b/examples/gallery/ma-chen.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import MaChen
 
 # setup system (parameters from Figure 5.55 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/morris-lecar.py
+++ b/examples/gallery/morris-lecar.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import MorrisLecar, StandardMorrisLecarParameter
 
 # setup system (parameters from Section 4.2 and Figure 11 from [Shi2014])
@@ -41,7 +42,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.L1(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     source_jac=func.source_jac,

--- a/examples/gallery/newton-leipnik.py
+++ b/examples/gallery/newton-leipnik.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import NewtonLeipnik
 
 # setup system (parameters from Figure 5.46 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/pif.py
+++ b/examples/gallery/pif.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import pif
 from pycaputo.typing import Array
 
@@ -46,7 +47,7 @@ print(control)
 
 # setup stepper
 stepper = pif.CaputoPerfectIntegrateFireL1Method(
-    derivative_order=(alpha,),
+    ds=(D(alpha),),
     control=control,
     y0=(y0,),
     source=model,

--- a/examples/gallery/qi.py
+++ b/examples/gallery/qi.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Qi
 
 # setup system (parameters from Figure 5 from [Qi2005])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/rossler.py
+++ b/examples/gallery/rossler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Rossler
 
 # setup system (parameters from Figure 5.44 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/van-der-pol.py
+++ b/examples/gallery/van-der-pol.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import VanDerPol
 
 # setup system (parameters from Figure 5.26 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/gallery/volta.py
+++ b/examples/gallery/volta.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from pycaputo import fracevolve, fracplot
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode.gallery import Volta
 
 # setup system (parameters from Figure 5.62 from [Petras2011])
@@ -26,7 +27,7 @@ print(control)
 from pycaputo.fode import caputo
 
 stepper = caputo.PECE(
-    derivative_order=alpha,
+    ds=tuple(D(alpha_i) for alpha_i in alpha),
     control=control,
     source=func.source,
     y0=(y0,),

--- a/examples/integrate-and-fire-ad-ex.py
+++ b/examples/integrate-and-fire-ad-ex.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import ad_ex
 from pycaputo.logging import get_logger
 
@@ -54,7 +55,7 @@ c: Controller = make_jannelli_controller(
 )
 
 stepper = ad_ex.CaputoAdExIntegrateFireL1Model(
-    derivative_order=alpha,
+    ds=(D(alpha[0]), D(alpha[1])),
     control=c,
     y0=(y0,),
     source=model,

--- a/examples/integrate-and-fire-eif.py
+++ b/examples/integrate-and-fire-eif.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import eif
 from pycaputo.logging import get_logger
 
@@ -53,7 +54,7 @@ c = make_jannelli_controller(
 )
 
 stepper = eif.CaputoExponentialIntegrateFireL1Method(
-    derivative_order=(alpha,),
+    ds=(D(alpha),),
     control=c,
     y0=(y0,),
     source=model,

--- a/examples/integrate-and-fire-lif.py
+++ b/examples/integrate-and-fire-lif.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import lif
 from pycaputo.logging import get_logger
 
@@ -50,7 +51,7 @@ c = make_jannelli_controller(
 )
 
 stepper = lif.CaputoLeakyIntegrateFireL1Method(
-    derivative_order=(alpha,),
+    ds=(D(alpha),),
     control=c,
     y0=(y0,),
     source=model,

--- a/examples/integrate-and-fire-pif.py
+++ b/examples/integrate-and-fire-pif.py
@@ -7,6 +7,7 @@ import math
 
 import numpy as np
 
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.integrate_fire import pif
 from pycaputo.logging import get_logger
 
@@ -52,7 +53,7 @@ c = make_jannelli_controller(
 )
 
 stepper = pif.CaputoPerfectIntegrateFireL1Method(
-    derivative_order=(alpha,),
+    ds=(D(alpha),),
     control=c,
     y0=(y0,),
     source=model,

--- a/examples/lorenz-weighted-euler.py
+++ b/examples/lorenz-weighted-euler.py
@@ -37,6 +37,7 @@ def lorenz_jac(t: float, y: Array, *, sigma: float, rho: float, beta: float) -> 
 # {{{ solve
 
 from pycaputo.controller import make_fixed_controller
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode import caputo
 
 # NOTE: example taken from Figure 1 in https://doi.org/10.1103/PhysRevLett.91.034101
@@ -47,7 +48,7 @@ beta = 8.0 / 3.0
 y0 = np.array([10.0, 0.0, 10.0])
 
 stepper = caputo.WeightedEuler(
-    derivative_order=alpha,
+    ds=tuple(D(a) for a in alpha),
     control=make_fixed_controller(1.0e-3, tstart=0.0, tfinal=25.0),
     source=partial(lorenz, sigma=sigma, rho=rho, beta=beta),
     source_jac=partial(lorenz_jac, sigma=sigma, rho=rho, beta=beta),

--- a/examples/tutorial-brusselator.py
+++ b/examples/tutorial-brusselator.py
@@ -37,6 +37,7 @@ def brusselator(t: float, y: Array, *, a: float, mu: float) -> Array:
 
 # [tutorial-method-start]
 from pycaputo.controller import make_fixed_controller
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode import caputo
 
 alpha = 0.8
@@ -45,7 +46,7 @@ mu = 4.0
 y0 = np.array([1.0, 2.0])
 
 stepper = caputo.PECE(
-    derivative_order=(alpha, alpha),
+    ds=(D(alpha), D(alpha)),
     control=make_fixed_controller(1.0e-2, tstart=0.0, tfinal=50.0),
     source=partial(brusselator, a=a, mu=mu),
     y0=(y0,),

--- a/examples/tutorial-van-der-pol-adaptive.py
+++ b/examples/tutorial-van-der-pol-adaptive.py
@@ -47,6 +47,7 @@ def van_der_pol_jac(t: float, y: Array, *, mu: float = 4.0) -> Array:
 
 # [tutorial-controller-start]
 from pycaputo.controller import make_jannelli_controller
+from pycaputo.derivatives import CaputoDerivative as D
 from pycaputo.fode import caputo
 
 tstart, tfinal = 0.0, 4.0
@@ -68,7 +69,7 @@ alpha = 0.8
 y0 = np.array([1.0, 0.0])
 
 m = caputo.PECE(
-    derivative_order=(alpha, alpha),
+    ds=(D(alpha), D(alpha)),
     control=c,
     source=van_der_pol,
     y0=(y0,),

--- a/src/pycaputo/__init__.py
+++ b/src/pycaputo/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pathlib
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -21,6 +21,10 @@ from pycaputo.grid import Points
 from pycaputo.logging import get_logger
 from pycaputo.stepping import FractionalDifferentialEquationMethod
 from pycaputo.typing import Array, ArrayOrScalarFunction, PathLike, ScalarFunction
+
+if TYPE_CHECKING:
+    from pycaputo.derivatives import FractionalOperatorT
+    from pycaputo.typing import StateFunctionT
 
 log = get_logger("pycaputo")
 
@@ -167,7 +171,7 @@ class Solution:
 
 
 def fracevolve(
-    m: FractionalDifferentialEquationMethod[Any],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     *,
     dtinit: float | None = None,
     quiet: bool = False,

--- a/src/pycaputo/controller.py
+++ b/src/pycaputo/controller.py
@@ -13,6 +13,7 @@ from pycaputo.typing import Array, StateFunction, StateFunctionT
 
 if TYPE_CHECKING:
     # NOTE: avoid cyclic import
+    from pycaputo.derivatives import FractionalOperatorT
     from pycaputo.stepping import FractionalDifferentialEquationMethod
 
 # {{{ utils
@@ -187,7 +188,7 @@ class Controller:
 @singledispatch
 def evaluate_error_estimate(
     c: Controller,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     trunc: Array,
     y: Array,
     yprev: Array,
@@ -213,7 +214,9 @@ def evaluate_error_estimate(
 
 @singledispatch
 def evaluate_timestep_factor(
-    c: Controller, m: FractionalDifferentialEquationMethod[StateFunctionT], eest: float
+    c: Controller,
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
+    eest: float,
 ) -> float:
     """Compute a factor for the step size control.
 
@@ -226,7 +229,7 @@ def evaluate_timestep_factor(
 @singledispatch
 def evaluate_timestep_accept(
     c: Controller,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -251,7 +254,7 @@ def evaluate_timestep_accept(
 @singledispatch
 def evaluate_timestep_reject(
     c: Controller,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -325,7 +328,7 @@ class FixedController(Controller):
 @evaluate_error_estimate.register(FixedController)
 def _evaluate_error_estimate_fixed(
     c: FixedController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     trunc: Array,
     y: Array,
     yprev: Array,
@@ -336,7 +339,7 @@ def _evaluate_error_estimate_fixed(
 @evaluate_timestep_factor.register(FixedController)
 def _evaluate_timestep_factor_fixed(
     c: FixedController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     eest: float,
 ) -> float:
     return 1.0
@@ -345,7 +348,7 @@ def _evaluate_timestep_factor_fixed(
 @evaluate_timestep_accept.register(FixedController)
 def _evaluate_timestep_accept_fixed(
     c: FixedController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -453,7 +456,7 @@ class GradedController(Controller):
 @evaluate_error_estimate.register(GradedController)
 def _evaluate_error_estimate_graded(
     c: GradedController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     trunc: Array,
     y: Array,
     yprev: Array,
@@ -464,7 +467,7 @@ def _evaluate_error_estimate_graded(
 @evaluate_timestep_factor.register(GradedController)
 def _evaluate_timestep_factor_graded(
     c: GradedController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     eest: float,
 ) -> float:
     return 1.0
@@ -473,7 +476,7 @@ def _evaluate_timestep_factor_graded(
 @evaluate_timestep_accept.register(GradedController)
 def _evaluate_timestep_accept_graded(
     c: GradedController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -575,7 +578,7 @@ class AdaptiveController(Controller):
 @evaluate_error_estimate.register(AdaptiveController)
 def _evaluate_error_estimate_adaptive(
     c: AdaptiveController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     trunc: Array,
     y: Array,
     yprev: Array,
@@ -617,7 +620,7 @@ class IntegralController(AdaptiveController):
 @evaluate_timestep_factor.register(IntegralController)
 def _evaluate_timestep_factor_integral(
     c: IntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     eest: float,
 ) -> float:
     if eest == 0.0:
@@ -633,7 +636,7 @@ def _evaluate_timestep_factor_integral(
 @evaluate_timestep_accept.register(IntegralController)
 def _evaluate_timestep_accept_integral(
     c: IntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -657,7 +660,7 @@ def _evaluate_timestep_accept_integral(
 @evaluate_timestep_reject.register(IntegralController)
 def _evaluate_timestep_reject_integral(
     c: IntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -706,7 +709,7 @@ class ProportionalIntegralController(AdaptiveController):
 @evaluate_timestep_factor.register(ProportionalIntegralController)
 def _evaluate_timestep_factor_proportional_integral(
     c: ProportionalIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     eest: float,
 ) -> float:
     if eest == 0.0:
@@ -732,7 +735,7 @@ def _evaluate_timestep_factor_proportional_integral(
 @evaluate_timestep_accept.register(ProportionalIntegralController)
 def _evaluate_timestep_accept_proportional_integral(
     c: ProportionalIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -758,7 +761,7 @@ def _evaluate_timestep_accept_proportional_integral(
 @evaluate_timestep_reject.register(ProportionalIntegralController)
 def _evaluate_timestep_reject_proportional_integral(
     c: ProportionalIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -866,7 +869,7 @@ class JannelliIntegralController(AdaptiveController):
 @evaluate_error_estimate.register(JannelliIntegralController)
 def _evaluate_error_estimate_jannelli(
     c: JannelliIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     trunc: Array,
     y: Array,
     yprev: Array,
@@ -890,7 +893,7 @@ def _evaluate_error_estimate_jannelli(
 @evaluate_timestep_factor.register(JannelliIntegralController)
 def _evaluate_timestep_factor_jannelli(
     c: JannelliIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     eest: float,
 ) -> float:
     if eest < 0.0:
@@ -906,7 +909,7 @@ def _evaluate_timestep_factor_jannelli(
 @evaluate_timestep_accept.register(JannelliIntegralController)
 def _evaluate_timestep_accept_jannelli(
     c: JannelliIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -925,7 +928,7 @@ def _evaluate_timestep_accept_jannelli(
 @evaluate_timestep_reject.register(JannelliIntegralController)
 def _evaluate_timestep_reject_jannelli(
     c: JannelliIntegralController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],
@@ -1021,7 +1024,7 @@ def make_random_controller(
 @evaluate_error_estimate.register(RandomController)
 def _evaluate_error_estimate_random(
     c: RandomController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     trunc: Array,
     y: Array,
     yprev: Array,
@@ -1032,7 +1035,7 @@ def _evaluate_error_estimate_random(
 @evaluate_timestep_factor.register(RandomController)
 def _evaluate_timestep_factor_random(
     c: RandomController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     eest: float,
 ) -> float:
     return 1.0
@@ -1041,7 +1044,7 @@ def _evaluate_timestep_factor_random(
 @evaluate_timestep_accept.register(RandomController)
 def _evaluate_timestep_accept_random(
     c: RandomController,
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     q: float,
     dtprev: float,
     state: dict[str, Any],

--- a/src/pycaputo/derivatives.py
+++ b/src/pycaputo/derivatives.py
@@ -32,6 +32,7 @@ class FractionalOperator:
 
 
 FractionalOperatorT = TypeVar("FractionalOperatorT", bound=FractionalOperator)
+"""A :class:`~typing.TypeVar` bound to :class:`FractionalOperator`."""
 
 
 @dataclass(frozen=True)

--- a/src/pycaputo/derivatives.py
+++ b/src/pycaputo/derivatives.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import enum
 import math
 from dataclasses import dataclass
+from typing import TypeVar
 
 
 class Side(enum.Enum):
@@ -28,6 +29,9 @@ class FractionalOperator:
 
     For a recent review of these operators see [SalesTeodoro2019]_.
     """
+
+
+FractionalOperatorT = TypeVar("FractionalOperatorT", bound=FractionalOperator)
 
 
 @dataclass(frozen=True)

--- a/src/pycaputo/fode/product_integration.py
+++ b/src/pycaputo/fode/product_integration.py
@@ -9,6 +9,7 @@ from typing import Any, NamedTuple
 
 import numpy as np
 
+from pycaputo.derivatives import FractionalOperatorT
 from pycaputo.events import Event
 from pycaputo.history import History, ProductIntegrationHistory
 from pycaputo.logging import get_logger
@@ -36,7 +37,9 @@ class AdvanceResult(NamedTuple):
 
 
 @dataclass(frozen=True)
-class ProductIntegrationMethod(FractionalDifferentialEquationMethod[StateFunctionT]):
+class ProductIntegrationMethod(
+    FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT]
+):
     """A generic class of methods based on Product Integration.
 
     In general, these methods support a variable time step.
@@ -54,7 +57,7 @@ class ProductIntegrationMethod(FractionalDifferentialEquationMethod[StateFunctio
 
 @evolve.register(ProductIntegrationMethod)
 def _evolve_pi(
-    m: FractionalDifferentialEquationMethod[StateFunctionT],
+    m: FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunctionT],
     *,
     history: History[Any] | None = None,
     dtinit: float | None = None,

--- a/src/pycaputo/integrate_fire/base.py
+++ b/src/pycaputo/integrate_fire/base.py
@@ -10,6 +10,7 @@ from functools import cached_property
 from typing import Any, NamedTuple, TypeVar
 
 import numpy as np
+from scipy.special import gamma
 
 from pycaputo import events
 from pycaputo.derivatives import CaputoDerivative, Side
@@ -19,7 +20,6 @@ from pycaputo.stepping import (
     FractionalDifferentialEquationMethod,
     advance,
     evolve,
-    gamma2m,
     make_initial_condition,
 )
 from pycaputo.typing import Array
@@ -345,7 +345,7 @@ def advance_caputo_integrate_fire_l1(
 
     # compute convolution coefficients
     alpha = m.alpha.reshape(-1, 1)
-    g2m = gamma2m(m).reshape(-1, 1)
+    g2m = gamma(2 - alpha)
 
     omega = (ts[:-1] ** (1 - alpha) - ts[1:] ** (1 - alpha)) / g2m
     h = (omega / np.diff(history.ts[: n + 1])).T

--- a/src/pycaputo/stepping.py
+++ b/src/pycaputo/stepping.py
@@ -90,18 +90,23 @@ class FractionalDifferentialEquationMethod(
     @abstractmethod
     def derivative_order(self) -> tuple[float, ...]:
         """A number that represents the *fractional* order of the operators in
-        :attr:`d`. For example, in the case of the Caputo derivative, this is
-        just the order :math:`\alpha`.
+        :attr:`~pycaputo.stepping.FractionalDifferentialEquationMethod.ds`. For
+        example, in the case of the Caputo derivative, this is just the order
+        :math:`\alpha`.
         """
 
     @cached_property
     def smallest_derivative_order(self) -> float:
-        """Smallest value of the :attr:`derivative_order`."""
+        """Smallest value of the
+        :attr:`~pycaputo.stepping.FractionalDifferentialEquationMethod.derivative_order`.
+        """
         return min(self.derivative_order)
 
     @cached_property
     def largest_derivative_order(self) -> float:
-        """Largest value of the :attr:`derivative_order`."""
+        """Largest value of the
+        :attr:`~pycaputo.stepping.FractionalDifferentialEquationMethod.derivative_order`.
+        """
         return max(self.derivative_order)
 
     @property

--- a/src/pycaputo/stepping.py
+++ b/src/pycaputo/stepping.py
@@ -10,35 +10,15 @@ from functools import cached_property, singledispatch
 from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
-from scipy.special import gamma
 
 from pycaputo.derivatives import FractionalOperator
 from pycaputo.events import Event
 from pycaputo.history import History
 from pycaputo.typing import Array, StateFunctionT
-from pycaputo.utils import cached_on_first_arg
 
 if TYPE_CHECKING:
     # NOTE: avoid cyclic import
     from pycaputo.controller import Controller
-
-
-@cached_on_first_arg
-def gamma1p(m: FractionalDifferentialEquationMethod[StateFunctionT]) -> Array:
-    r"""A cached vectorized value of :math:`\Gamma(1 + \alpha_i)`."""
-    return gamma(1 + m.alpha)  # type: ignore[no-any-return]
-
-
-@cached_on_first_arg
-def gamma2p(m: FractionalDifferentialEquationMethod[StateFunctionT]) -> Array:
-    r"""A cached vectorized value of :math:`\Gamma(2 + \alpha_i)`."""
-    return gamma(2 + m.alpha)  # type: ignore[no-any-return]
-
-
-@cached_on_first_arg
-def gamma2m(m: FractionalDifferentialEquationMethod[StateFunctionT]) -> Array:
-    r"""A cached vectorized value of :math:`\Gamma(2 - \alpha_i)`."""
-    return gamma(2 - m.alpha)  # type: ignore[no-any-return]
 
 
 @dataclass(frozen=True)

--- a/tests/test_fode.py
+++ b/tests/test_fode.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from pycaputo.controller import Controller
+from pycaputo.derivatives import CaputoDerivative
 from pycaputo.logging import get_logger
 from pycaputo.utils import get_environ_bool, set_recommended_matplotlib
 
@@ -113,7 +114,7 @@ def _check_fixed_controller_evolution(
         evaluate_timestep_accept,
         evaluate_timestep_factor,
     )
-    from pycaputo.fode.caputo import ForwardEuler
+    from pycaputo.fode import caputo
 
     assert c.tfinal is not None
     assert c.nsteps is not None
@@ -124,8 +125,8 @@ def _check_fixed_controller_evolution(
     yprev = rng.normal(size=ncomponents)
     trunc = rng.normal(size=ncomponents)
 
-    m = ForwardEuler(
-        derivative_order=(0.8,) * y.size,
+    m = caputo.ForwardEuler(
+        ds=(CaputoDerivative(0.8),) * y.size,
         control=c,
         source=lambda t, y: np.zeros_like(y),
         y0=(yprev,),
@@ -202,11 +203,11 @@ def test_graded_controller() -> None:
     assert c.tfinal is not None
     assert c.nsteps is not None
 
-    from pycaputo.fode.caputo import ForwardEuler
+    from pycaputo.fode import caputo
 
     y0 = np.zeros(7)
-    m = ForwardEuler(
-        derivative_order=(0.8,) * y0.size,
+    m = caputo.ForwardEuler(
+        ds=(CaputoDerivative(0.8),) * y0.size,
         control=c,
         source=lambda t, y: np.zeros_like(y0),
         y0=(y0,),

--- a/tests/test_fode_caputo.py
+++ b/tests/test_fode_caputo.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.linalg as la
 import pytest
 
+from pycaputo.derivatives import FractionalOperatorT
 from pycaputo.fode import caputo
 from pycaputo.logging import get_logger
 from pycaputo.stepping import FractionalDifferentialEquationMethod, evolve
@@ -77,7 +78,9 @@ def garrappa2009_source_jac(t: float, y: Array, *, alpha: float) -> Array:
 
 
 def fode_factory(
-    cls: type[FractionalDifferentialEquationMethod[StateFunction]],
+    cls: type[
+        FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunction]
+    ],
     *,
     wrap: bool = True,
     graded: bool = False,
@@ -105,7 +108,7 @@ def fode_factory(
 
     def wrapper(
         alpha: float | tuple[float, ...], n: int
-    ) -> FractionalDifferentialEquationMethod[StateFunction]:
+    ) -> FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunction]:
         if not isinstance(alpha, tuple):
             alpha = (alpha,)
 
@@ -162,7 +165,8 @@ def fode_factory(
 @pytest.mark.parametrize("alpha", [0.1, 0.5, 0.9])
 def test_fode_caputo(
     factory: Callable[
-        [float, int], FractionalDifferentialEquationMethod[StateFunction]
+        [float, int],
+        FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunction],
     ],
     alpha: float,
 ) -> None:
@@ -249,7 +253,8 @@ def test_fode_caputo(
 )
 def test_fode_caputo_system(
     factory: Callable[
-        [tuple[float, ...], int], FractionalDifferentialEquationMethod[StateFunction]
+        [tuple[float, ...], int],
+        FractionalDifferentialEquationMethod[FractionalOperatorT, StateFunction],
     ],
 ) -> None:
     """

--- a/tests/test_integrate_fire.py
+++ b/tests/test_integrate_fire.py
@@ -183,6 +183,7 @@ def test_ad_ex_lambert_limits() -> None:
     from math import gamma
 
     from pycaputo.controller import make_jannelli_controller
+    from pycaputo.derivatives import CaputoDerivative as D
     from pycaputo.integrate_fire.ad_ex import (
         AD_EX_PARAMS,
         AdExModel,
@@ -219,7 +220,7 @@ def test_ad_ex_lambert_limits() -> None:
         ])
 
         method = CaputoAdExIntegrateFireL1Model(
-            derivative_order=alpha,
+            ds=(D(alpha[0]), D(alpha[1])),
             control=make_jannelli_controller(chimin=0.1, chimax=1.0),
             y0=(y0,),
             source=ad_ex,
@@ -277,6 +278,7 @@ def test_ad_ex_solve() -> None:
     """
 
     from pycaputo.controller import make_jannelli_controller
+    from pycaputo.derivatives import CaputoDerivative as D
     from pycaputo.integrate_fire.ad_ex import (
         AD_EX_PARAMS,
         AdExModel,
@@ -298,7 +300,7 @@ def test_ad_ex_solve() -> None:
             t = dt
             y0 = np.array([rng.uniform(param.v_reset, param.v_peak), rng.uniform()])
             method = CaputoAdExIntegrateFireL1Model(
-                derivative_order=alpha,
+                ds=(D(alpha[0]), D(alpha[1])),
                 control=make_jannelli_controller(chimin=0.1, chimax=1.0),
                 y0=(y0,),
                 source=ad_ex,
@@ -354,6 +356,7 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
     y0 = np.array([rng.uniform(model.param.v_reset, model.param.v_peak)])
 
     from pycaputo.controller import make_jannelli_controller
+    from pycaputo.derivatives import CaputoDerivative as D
     from pycaputo.stepping import evolve
     from pycaputo.utils import EOCRecorder, stringify_eoc
 
@@ -382,7 +385,7 @@ def test_pif_model(alpha: float, resolutions: list[tuple[float, float]]) -> None
         )
 
         stepper = pif.CaputoPerfectIntegrateFireL1Method(
-            derivative_order=(alpha,),
+            ds=(D(alpha),),
             control=c,
             y0=(y0,),
             source=model,


### PR DESCRIPTION
Mostly switch from providing `derivative_order=alpha`, which only works for Caputo and Riemann-Liouville, to providing `ds=(op, ...)` the derivative operators.